### PR TITLE
Stream eviction and manifest cache API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ WHERE temperature > 80.0 OR humidity > 95.0;
 ```sql
 -- Create user with audit trail
 CREATE USER TABLE app.user_data (
-  id BIGINT DEFAULT SNOWFLAKE_ID(),
+  id BIGINT PRIMARY KEY DEFAULT SNOWFLAKE_ID(),
   data_type TEXT,
   content TEXT,
   created_by TEXT DEFAULT CURRENT_USER(),
@@ -410,7 +410,7 @@ DROP USER 'alice';
 ```sql
 -- Tenant-isolated data
 CREATE USER TABLE saas.customer_data (
-  id BIGINT DEFAULT SNOWFLAKE_ID(),
+  id BIGINT PRIMARY KEY DEFAULT SNOWFLAKE_ID(),
   customer_id TEXT DEFAULT CURRENT_USER(),
   entity_type TEXT,
   entity_data TEXT,
@@ -419,6 +419,7 @@ CREATE USER TABLE saas.customer_data (
 
 -- Cross-tenant analytics (aggregated)
 CREATE SHARED TABLE saas.analytics (
+  id BIGINT PRIMARY KEY DEFAULT SNOWFLAKE_ID(),
   metric_name TEXT,
   metric_value DOUBLE,
   tenant_id TEXT,

--- a/backend/crates/kalamdb-core/src/providers/streams.rs
+++ b/backend/crates/kalamdb-core/src/providers/streams.rs
@@ -93,6 +93,11 @@ impl StreamTableProvider {
         }
     }
 
+    /// Expose the underlying store (used by maintenance jobs such as stream eviction)
+    pub fn store_arc(&self) -> Arc<StreamTableStore> {
+        self.store.clone()
+    }
+
     /// Return a snapshot of all rows as JSON objects (no RLS filtering)
     ///
     /// Used by live initial snapshot where we need table-wide data. RLS is

--- a/backend/crates/kalamdb-core/src/schema_registry/system_columns_service.rs
+++ b/backend/crates/kalamdb-core/src/schema_registry/system_columns_service.rs
@@ -105,7 +105,7 @@ impl SystemColumnsService {
 
     /// Add system columns to a table definition
     ///
-    /// **MVCC Architecture**: Injects `_seq BIGINT`, `_updated DATETIME(UTC)`, and `_deleted BOOLEAN`
+    /// **MVCC Architecture**: Injects `_seq BIGINT`, `_updated TIMESTAMP`, and `_deleted BOOLEAN`
     /// columns if they don't already exist.
     ///
     /// # Arguments
@@ -137,6 +137,18 @@ impl SystemColumnsService {
             is_partition_key: false,
             default_value: ColumnDefault::None,
             column_comment: Some("System-generated Snowflake-based version ID (MVCC) with embedded timestamp".to_string()),
+        });
+
+        // Add _updated column (TIMESTAMP, NOT NULL)
+        table_def.columns.push(ColumnDefinition {
+            column_name: "_updated".to_string(),
+            ordinal_position: next_ordinal + 1,
+            data_type: kalamdb_commons::models::datatypes::KalamDataType::Timestamp,
+            is_nullable: false,
+            is_primary_key: false,
+            is_partition_key: false,
+            default_value: ColumnDefault::None,
+            column_comment: Some("System-generated last update timestamp (UTC)".to_string()),
         });
 
         // Add _deleted column (BOOLEAN, NOT NULL, DEFAULT FALSE)

--- a/backend/crates/kalamdb-sql/examples/parse_subscribe.rs
+++ b/backend/crates/kalamdb-sql/examples/parse_subscribe.rs
@@ -1,0 +1,11 @@
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+fn main() {
+    let sql = "SELECT * FROM app.messages WHERE user_id = CURRENT_USER()";
+    let dialect = GenericDialect {};
+    match Parser::parse_sql(&dialect, sql) {
+        Ok(ast) => println!("Parsed AST: {:?}", ast),
+        Err(e) => eprintln!("Parse error: {}", e),
+    }
+}

--- a/backend/crates/kalamdb-sql/src/parser/extensions.rs
+++ b/backend/crates/kalamdb-sql/src/parser/extensions.rs
@@ -225,6 +225,7 @@ mod tests {
     fn test_parse_subscribe_with_where() {
         let sql = "SUBSCRIBE TO app.messages WHERE user_id = CURRENT_USER()";
         let result = ExtensionStatement::parse(sql);
+        
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), ExtensionStatement::Subscribe(_)));
     }


### PR DESCRIPTION
Refactored stream eviction job to use registered StreamTableProvider and improved handling of empty tables. Updated manifest cache and flush integration tests to use UserId consistently for user-scoped operations. Added new helper methods and tests for SeqId and stream eviction logic. Fixed TTL detection for stream tables in JobsManager. Minor doc and schema updates in README.