### PR TITLE
Enforce table access controls and mask password hashes

### DIFF
--- a/backend/crates/kalamdb-api/src/handlers/sql_handler.rs
+++ b/backend/crates/kalamdb-api/src/handlers/sql_handler.rs
@@ -498,6 +498,21 @@ fn record_batch_to_query_result(
                     }
                 }
             }
+
+            // Mask password_hash column
+            if let Some(pwd_col) = column_names
+                .iter()
+                .position(|name| name.eq_ignore_ascii_case("password_hash"))
+            {
+                let key = column_names[pwd_col].clone();
+                for row in rows.iter_mut() {
+                    if let Some(value) = row.get_mut(&key) {
+                        if !value.is_null() {
+                            *value = serde_json::Value::String("***".to_string());
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/backend/crates/kalamdb-commons/src/websocket.rs
+++ b/backend/crates/kalamdb-commons/src/websocket.rs
@@ -199,6 +199,10 @@ pub struct SubscriptionOptions {
     /// Optional: Configure batch size for initial data streaming
     #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<usize>,
+
+    /// Optional: Number of last rows to fetch for initial data
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_rows: Option<u32>,
 }
 
 /// Batch control metadata for paginated initial data loading

--- a/backend/src/lifecycle.rs
+++ b/backend/src/lifecycle.rs
@@ -179,7 +179,7 @@ pub async fn bootstrap(
 
     // JWT authentication
     use jsonwebtoken::Algorithm;
-    let jwt_secret = "kalamdb-dev-secret-key-change-in-production".to_string();
+    let jwt_secret = config.auth.jwt_secret.clone();
     let jwt_auth = Arc::new(JwtAuth::new(jwt_secret, Algorithm::HS256));
     info!("JWT authentication initialized (HS256)");
 

--- a/docs/Notes.md
+++ b/docs/Notes.md
@@ -240,6 +240,8 @@ instead of: 1 failed: Invalid operation: No handler registered for statement typ
   - specify batch size and verify it works correctly
   - with seq bounds
   - with time bounds in streams with ttl passed
+  - Check the order of the recieved rows is correct in the batch
+  - Check if the rows is correct in the changes notification as well
 
 Here’s the updated 5-line spec with embedding storage inside Parquet and managed HNSW indexing (with delete handling):
 	1.	Parquet Storage: All embeddings are stored as regular columns in the Parquet file alongside other table columns to keep data unified and versioned per batch.


### PR DESCRIPTION
Adds security checks to restrict access to user and system tables based on user roles in both live query subscriptions and SQL execution. Password hashes are now masked in query results. Implements lazy loading for table schemas in the registry, primes cache for stream tables, and makes JWT secret configurable. Updates documentation and test notes accordingly.