### PR TITLE
Prompt for password interactively if flag is present

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -46,8 +46,8 @@ pub struct Cli {
     #[arg(long = "username")]
     pub username: Option<String>,
 
-    /// HTTP Basic Auth password
-    #[arg(long = "password")]
+    /// HTTP Basic Auth password (if flag is present without value, prompts interactively)
+    #[arg(long = "password", num_args = 0..=1, default_missing_value = "")]
     pub password: Option<String>,
 
     /// Database instance name (for credential storage)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,15 @@ use connect::create_session;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Parse command-line arguments
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
+
+    // If --password flag was provided without a value (empty string), prompt interactively
+    // This keeps the password out of the process list for security
+    if cli.password.as_ref().map(|p| p.is_empty()).unwrap_or(false) {
+        let password = rpassword::prompt_password("Password: ")
+            .map_err(|e| CLIError::FileError(format!("Failed to read password: {}", e)))?;
+        cli.password = Some(password);
+    }
 
     // Initialize logging (basic)
     if cli.verbose {


### PR DESCRIPTION
Updated the --password CLI argument to allow prompting for password interactively when the flag is provided without a value. This improves security by keeping the password out of the process list.