### PR TITLE
Remove unnecessary unsafe Send/Sync impls and update RocksDB usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"]
 chrono = { version = "0.4.38", features = ["serde"] }
 
 # Storage
-rocksdb = { version = "0.24.0", default-features = false, features = ["snappy"] }
+rocksdb = { version = "0.24.0", default-features = false, features = ["snappy", "multi-threaded-cf"] }
 
 # Apache Arrow ecosystem
 arrow = { version = "57.0.0", features = ["prettyprint"] }

--- a/backend/crates/kalamdb-commons/src/models/ids/audit_log_id.rs
+++ b/backend/crates/kalamdb-commons/src/models/ids/audit_log_id.rs
@@ -63,10 +63,6 @@ impl AsRef<[u8]> for AuditLogId {
     }
 }
 
-// Safety: string wrapper is naturally Send + Sync.
-unsafe impl Send for AuditLogId {}
-unsafe impl Sync for AuditLogId {}
-
 impl StorageKey for AuditLogId {
     fn storage_key(&self) -> Vec<u8> {
         self.0.as_bytes().to_vec()

--- a/backend/crates/kalamdb-commons/src/models/ids/job_id.rs
+++ b/backend/crates/kalamdb-commons/src/models/ids/job_id.rs
@@ -66,10 +66,6 @@ impl AsRef<[u8]> for JobId {
     }
 }
 
-// Ensure Send and Sync are implemented
-unsafe impl Send for JobId {}
-unsafe impl Sync for JobId {}
-
 impl StorageKey for JobId {
     fn storage_key(&self) -> Vec<u8> {
         self.0.as_bytes().to_vec()

--- a/backend/crates/kalamdb-commons/src/models/ids/live_query_id.rs
+++ b/backend/crates/kalamdb-commons/src/models/ids/live_query_id.rs
@@ -135,10 +135,6 @@ impl AsRef<[u8]> for LiveQueryId {
     }
 }
 
-// Ensure Send and Sync are implemented
-unsafe impl Send for LiveQueryId {}
-unsafe impl Sync for LiveQueryId {}
-
 impl StorageKey for LiveQueryId {
     fn storage_key(&self) -> Vec<u8> {
         self.to_string().into_bytes()

--- a/backend/crates/kalamdb-commons/src/models/ids/row_id.rs
+++ b/backend/crates/kalamdb-commons/src/models/ids/row_id.rs
@@ -67,10 +67,6 @@ impl fmt::Display for RowId {
     }
 }
 
-// Ensure Send and Sync are implemented
-unsafe impl Send for RowId {}
-unsafe impl Sync for RowId {}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/crates/kalamdb-commons/src/models/ids/table_id.rs
+++ b/backend/crates/kalamdb-commons/src/models/ids/table_id.rs
@@ -104,10 +104,6 @@ impl fmt::Display for TableId {
     }
 }
 
-// Ensure Send and Sync are implemented
-unsafe impl Send for TableId {}
-unsafe impl Sync for TableId {}
-
 impl StorageKey for TableId {
     fn storage_key(&self) -> Vec<u8> {
         self.as_storage_key()

--- a/backend/crates/kalamdb-commons/src/models/ids/user_row_id.rs
+++ b/backend/crates/kalamdb-commons/src/models/ids/user_row_id.rs
@@ -90,10 +90,6 @@ impl fmt::Display for UserRowId {
     }
 }
 
-// Ensure Send and Sync are implemented
-unsafe impl Send for UserRowId {}
-unsafe impl Sync for UserRowId {}
-
 impl StorageKey for UserRowId {
     fn storage_key(&self) -> Vec<u8> {
         self.as_storage_key()

--- a/backend/crates/kalamdb-commons/src/models/user_name.rs
+++ b/backend/crates/kalamdb-commons/src/models/user_name.rs
@@ -72,10 +72,6 @@ impl AsRef<[u8]> for UserName {
     }
 }
 
-// Ensure Send and Sync are implemented
-unsafe impl Send for UserName {}
-unsafe impl Sync for UserName {}
-
 impl StorageKey for UserName {
     fn storage_key(&self) -> Vec<u8> {
         self.0.as_bytes().to_vec()

--- a/specs/002-simple-kalamdb/progress/PHASE_18_DML_PROGRESS.md
+++ b/specs/002-simple-kalamdb/progress/PHASE_18_DML_PROGRESS.md
@@ -296,7 +296,6 @@
 ## 💡 Lessons Learned
 
 1. **System columns must be in Arrow schema**: DataFusion needs to know about all columns for SELECT queries
-2. **RocksDB CF creation is safe with unsafe code**: RocksDB's internal locking makes Arc→mut cast safe
 3. **Test schema consistency matters**: Generic "name/value" doesn't match realistic conversations schema
 4. **Empty batch handling is critical**: Zero rows must still return correct schema
 5. **Projection requires field cloning**: Can't just slice arrays, need to rebuild schema too

--- a/specs/004-system-improvements-and/agent-files/US6_COMPLETION_REPORT.md
+++ b/specs/004-system-improvements-and/agent-files/US6_COMPLETION_REPORT.md
@@ -53,7 +53,6 @@ Successfully implemented comprehensive code quality improvements across the Kala
 - ✅ T414: Created CODE_ORGANIZATION.md (comprehensive guide)
 - ✅ T411-T413: Audited rustdoc coverage (comprehensive across all public APIs)
 - ✅ T382: Audited From/Into trait usage (all correct)
-- ✅ T402: Audited unsafe code blocks (4 blocks, all documented)
 - ✅ T405: Verified error message consistency
 
 ## Test Results


### PR DESCRIPTION
Eliminated manual unsafe Send/Sync implementations for ID and user name types, relying on Rust's auto traits. Updated RocksDB backend to use the multi-threaded-cf feature, removing unsafe code and direct DB pointer manipulation. Adjusted documentation to reflect the removal of unsafe code blocks.