### PR TITLE
Add column sorting to Streaming Topics table

### DIFF
--- a/ui/src/pages/StreamingTopics.tsx
+++ b/ui/src/pages/StreamingTopics.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { RefreshCw, Search, ArrowRight } from "lucide-react";
+import { RefreshCw, Search, ArrowRight, ArrowUp, ArrowDown, ArrowUpDown } from "lucide-react";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { StreamingTabs } from "@/features/streaming/components/StreamingTabs";
 import { useGetStreamingTopicsQuery } from "@/store/apiSlice";
@@ -17,6 +17,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { formatTimestamp } from "@/lib/formatters";
+
+type SortKey = "topicId" | "partitions" | "routeCount" | "retentionSeconds" | "updatedAt";
+type SortDirection = "asc" | "desc";
 
 function formatNullableTimestamp(value: string | null): string {
   if (!value) {
@@ -41,6 +44,16 @@ export default function StreamingTopics() {
     refetch,
   } = useGetStreamingTopicsQuery();
   const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("topicId");
+  const [directions, setDirections] = useState<Record<SortKey, SortDirection>>({
+    topicId: "desc",
+    partitions: "desc",
+    routeCount: "desc",
+    retentionSeconds: "desc",
+    updatedAt: "desc",
+  });
+  const sortDirection = directions[sortKey];
+  const [sortedTopics, setSortedTopics] = useState<typeof topics>([]);
 
   const filteredTopics = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -53,6 +66,34 @@ export default function StreamingTopics() {
         topic.name.toLowerCase().includes(query),
     );
   }, [search, topics]);
+
+  useEffect(() => {
+    setSortedTopics(filteredTopics);
+  }, [filteredTopics]);
+
+  const applySort = (data: typeof topics, key: SortKey, direction: SortDirection) => {
+    const dir = direction === "desc" ? -1 : 1;
+    return [...data].sort((a, b) => {
+      const aVal = a[key];
+      const bVal = b[key];
+      if (aVal === null || aVal === undefined) return 1;
+      if (bVal === null || bVal === undefined) return -1;
+      if (typeof aVal === "string" && typeof bVal === "string") {
+        return aVal.localeCompare(bVal) * dir;
+      }
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return (aVal - bVal) * dir;
+      }
+      return 0;
+    });
+  };
+
+  const handleSort = (key: SortKey) => {
+    const newDirection = directions[key] === "asc" ? "desc" : "asc";
+    setSortKey(key);
+    setDirections((prev) => ({ ...prev, [key]: newDirection }));
+    setSortedTopics((prev) => applySort(prev, key, newDirection));
+  };
 
   const errorMessage =
     error && "error" in error && typeof error.error === "string"
@@ -94,7 +135,7 @@ export default function StreamingTopics() {
         <CardHeader className="pb-2">
           <CardTitle className="text-base">Topics</CardTitle>
           <CardDescription>
-            {filteredTopics.length} topic{filteredTopics.length === 1 ? "" : "s"} visible
+            {sortedTopics.length} topic{sortedTopics.length === 1 ? "" : "s"} visible
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -102,23 +143,38 @@ export default function StreamingTopics() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Topic</TableHead>
-                  <TableHead>Partitions</TableHead>
-                  <TableHead>Routes</TableHead>
-                  <TableHead>Retention (sec)</TableHead>
-                  <TableHead>Updated</TableHead>
+                  {([
+                    ["topicId", "Topic"],
+                    ["partitions", "Partitions"],
+                    ["routeCount", "Routes"],
+                    ["retentionSeconds", "Retention (sec)"],
+                    ["updatedAt", "Updated"],
+                  ] as [SortKey, string][]).map(([key, label]) => (
+                    <TableHead
+                      key={key}
+                      className="cursor-pointer select-none hover:text-foreground"
+                      onClick={() => handleSort(key)}
+                    >
+                      <span className="inline-flex items-center gap-1">
+                        {label}
+                        {sortKey === key
+                          ? (sortDirection === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />)
+                          : <ArrowUpDown className="h-3 w-3 opacity-30" />}
+                      </span>
+                    </TableHead>
+                  ))}
                   <TableHead className="w-[170px]">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredTopics.length === 0 ? (
+                {sortedTopics.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
                       {search.trim() ? "No topics match your search." : "No topics found."}
                     </TableCell>
                   </TableRow>
                 ) : (
-                  filteredTopics.map((topic) => (
+                  sortedTopics.map((topic) => (
                     <TableRow key={topic.topicId}>
                       <TableCell className="font-mono text-xs">{topic.topicId}</TableCell>
                       <TableCell>{topic.partitions}</TableCell>


### PR DESCRIPTION
Click any column header to sort. Each column remembers its last direction independently, and sorting stacks on top of the previous sort (equal values preserve their existing order via stable sort).