### PR TITLE
Add pagination, sorting, and sticky headers to audit logs and jobs tables

### DIFF
--- a/ui/src/components/audit/AuditLogList.tsx
+++ b/ui/src/components/audit/AuditLogList.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
-import type { AuditLog, AuditLogFilters } from '@/services/auditLogService';
+import type { AuditLog, AuditLogFilters, AuditLogSortKey } from '@/services/auditLogService';
 import { useGetAuditLogsQuery } from '@/store/apiSlice';
+import { formatUtcTimestamp } from '@/lib/formatters';
 import {
   Table,
   TableBody,
@@ -19,7 +20,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Loader2, RefreshCw, Filter, X, Eye } from 'lucide-react';
+import { Loader2, RefreshCw, Filter, X, Eye, ChevronLeft, ChevronRight, ArrowUp, ArrowDown, ArrowUpDown } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '@/lib/config';
 
 const ACTION_COLORS: Record<string, string> = {
   'CREATE': 'bg-green-100 text-green-800',
@@ -44,24 +47,38 @@ function getActionColor(action: string): string {
   return 'bg-gray-100 text-gray-800';
 }
 
-function formatTimestamp(timestamp: string): string {
-  try {
-    const date = new Date(timestamp);
-    return date.toLocaleString();
-  } catch {
-    return timestamp;
-  }
-}
 
   export function AuditLogList() {
     const [showFilters, setShowFilters] = useState(false);
     const [selectedLog, setSelectedLog] = useState<AuditLog | null>(null);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+    const [page, setPage] = useState(0);
+    const [sortBy, setSortBy] = useState<AuditLogSortKey>("timestamp");
+    const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
     const [draftFilters, setDraftFilters] = useState<AuditLogFilters>({
-      limit: 100,
+      limit: DEFAULT_PAGE_SIZE,
     });
     const [appliedFilters, setAppliedFilters] = useState<AuditLogFilters>({
-      limit: 100,
+      limit: DEFAULT_PAGE_SIZE,
+      offset: 0,
+      sortBy: "timestamp",
+      sortDirection: "desc",
     });
+
+    const handleSort = (key: AuditLogSortKey) => {
+      const newDirection = sortBy === key
+        ? (sortDirection === "asc" ? "desc" : "asc")
+        : "asc";
+      setSortBy(key);
+      setSortDirection(newDirection);
+      setPage(0);
+      setAppliedFilters((prev) => ({
+        ...prev,
+        sortBy: key,
+        sortDirection: newDirection,
+        offset: 0,
+      }));
+    };
     const { data: fetchedLogs, isLoading, error: queryError, refetch } = useGetAuditLogsQuery(appliedFilters, {
       pollingInterval: 5000,
     });
@@ -75,15 +92,28 @@ function formatTimestamp(timestamp: string): string {
         : null;
   
     const handleApplyFilters = () => {
-      setAppliedFilters({ ...draftFilters });
+      setPage(0);
+      setAppliedFilters({ ...draftFilters, limit: pageSize, offset: 0 });
       setShowFilters(false);
     };
-  
+
     const handleClearFilters = () => {
-      const clearedFilters = { limit: 100 };
-      setDraftFilters(clearedFilters);
+      const clearedFilters = { limit: pageSize, offset: 0 };
+      setPage(0);
+      setDraftFilters({ limit: pageSize });
       setAppliedFilters(clearedFilters);
       setShowFilters(false);
+    };
+
+    const handlePageChange = (newPage: number) => {
+      setPage(newPage);
+      setAppliedFilters((prev) => ({ ...prev, offset: newPage * pageSize }));
+    };
+
+    const handlePageSizeChange = (newSize: number) => {
+      setPageSize(newSize);
+      setPage(0);
+      setAppliedFilters((prev) => ({ ...prev, limit: newSize, offset: 0 }));
     };
   
     const handleRefresh = () => {
@@ -116,7 +146,7 @@ function formatTimestamp(timestamp: string): string {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col h-full min-h-0 gap-4">
       {/* Toolbar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -139,11 +169,49 @@ function formatTimestamp(timestamp: string): string {
             </Button>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">
-            {logs.length} log{logs.length !== 1 ? 's' : ''}
-          </span>
-          <Button variant="outline" size="icon" onClick={handleRefresh} disabled={isLoading} aria-label="Refresh audit logs">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Select
+              value={String(pageSize)}
+              onValueChange={(v) => handlePageSizeChange(Number(v))}
+            >
+              <SelectTrigger className="h-8 w-[70px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PAGE_SIZE_OPTIONS.map((size) => (
+                  <SelectItem key={size} value={String(size)}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span>per page</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              disabled={page === 0}
+              onClick={() => handlePageChange(page - 1)}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm text-muted-foreground px-2">
+              {page + 1}
+            </span>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              disabled={logs.length < pageSize}
+              onClick={() => handlePageChange(page + 1)}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+          <Button variant="outline" size="icon" className="h-8 w-8" onClick={handleRefresh} disabled={isLoading} aria-label="Refresh audit logs">
             <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
           </Button>
         </div>
@@ -178,15 +246,6 @@ function formatTimestamp(timestamp: string): string {
                   onChange={(e) => setDraftFilters({ ...draftFilters, target: e.target.value || undefined })}
                 />
               </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Limit</label>
-                <Input
-                  type="number"
-                  placeholder="100"
-                  value={draftFilters.limit || ''}
-                  onChange={(e) => setDraftFilters({ ...draftFilters, limit: parseInt(e.target.value, 10) || undefined })}
-                />
-              </div>
               <div className="flex items-end">
                 <Button onClick={handleApplyFilters} className="w-full">
                   <Filter className="mr-2 h-4 w-4" />
@@ -215,23 +274,38 @@ function formatTimestamp(timestamp: string): string {
           </CardHeader>
         </Card>
       ) : (
-        <div className="border rounded-lg">
-          <Table>
+        <div className="border rounded-lg flex-1 min-h-0 overflow-hidden [&>div]:h-full [&>div]:overflow-auto">
+          <Table className="border-separate border-spacing-0 [&_td]:border-b [&_td]:border-border">
             <TableHeader>
               <TableRow>
-                <TableHead>Timestamp</TableHead>
-                <TableHead>User</TableHead>
-                <TableHead>Action</TableHead>
-                <TableHead>Target</TableHead>
-                <TableHead>IP Address</TableHead>
-                <TableHead className="w-[80px]">Details</TableHead>
+                {([
+                  ["timestamp", "Timestamp"],
+                  ["actor_username", "User"],
+                  ["action", "Action"],
+                  ["target", "Target"],
+                  ["ip_address", "IP Address"],
+                ] as [AuditLogSortKey, string][]).map(([key, label]) => (
+                  <TableHead
+                    key={key}
+                    className="sticky top-0 bg-background z-10 border-b border-border cursor-pointer select-none hover:text-foreground"
+                    onClick={() => handleSort(key)}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {label}
+                      {sortBy === key
+                        ? (sortDirection === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />)
+                        : <ArrowUpDown className="h-3 w-3 opacity-30" />}
+                    </span>
+                  </TableHead>
+                ))}
+                <TableHead className="sticky top-0 bg-background z-10 border-b border-border w-[80px]">Details</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {logs.map((log) => (
                 <TableRow key={log.audit_id}>
                   <TableCell className="font-mono text-sm">
-                    {formatTimestamp(log.timestamp)}
+                    {formatUtcTimestamp(log.timestamp)}
                   </TableCell>
                   <TableCell>
                     <div>
@@ -278,7 +352,7 @@ function formatTimestamp(timestamp: string): string {
           <DialogHeader>
             <DialogTitle>Audit Log Details</DialogTitle>
             <DialogDescription>
-              {selectedLog && formatTimestamp(selectedLog.timestamp)}
+              {selectedLog && formatUtcTimestamp(selectedLog.timestamp)}
             </DialogDescription>
           </DialogHeader>
           {selectedLog && (

--- a/ui/src/components/jobs/JobList.tsx
+++ b/ui/src/components/jobs/JobList.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Job } from '@/services/jobService';
-import type { JobFilters } from '@/services/sql/queries/jobQueries';
+import type { JobFilters, JobSortKey } from '@/services/sql/queries/jobQueries';
 import { useGetJobsFilteredQuery } from '@/store/apiSlice';
 import {
   Table,
@@ -29,8 +29,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, RefreshCw, Filter, X, Eye, Play, CheckCircle, XCircle, Clock, AlertCircle } from 'lucide-react';
+import { Loader2, RefreshCw, Filter, X, Eye, Play, CheckCircle, XCircle, Clock, AlertCircle, ChevronLeft, ChevronRight, ArrowUp, ArrowDown, ArrowUpDown } from 'lucide-react';
 import { formatTimestamp, toMilliseconds } from '@/lib/formatters';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '@/lib/config';
 
 const STATUS_COLORS: Record<string, string> = {
   'New': 'bg-gray-100 text-gray-800',
@@ -65,7 +66,8 @@ function parseJobParams(parameters: string | null): { namespace_id?: string; tab
 }
 
 function getStatusColor(status: string): string {
-  return STATUS_COLORS[status] || 'bg-gray-100 text-gray-800';
+  const capitalized = status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+  return STATUS_COLORS[capitalized] || STATUS_COLORS[status] || 'bg-gray-100 text-gray-800';
 }
 
 function formatDuration(startedAt: string | null, finishedAt: string | null): string {
@@ -113,11 +115,18 @@ interface JobListProps {
 export function JobList({ initialFilters, compact = false, onJobClick }: JobListProps) {
   const [showFilters, setShowFilters] = useState(false);
   const [selectedJob, setSelectedJob] = useState<Job | null>(null);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = useState(0);
+  const [sortBy, setSortBy] = useState<JobSortKey>("created_at");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
   const [draftFilters, setDraftFilters] = useState<JobFilters>(initialFilters || {
-    limit: 100,
+    limit: DEFAULT_PAGE_SIZE,
   });
   const [appliedFilters, setAppliedFilters] = useState<JobFilters>(initialFilters || {
-    limit: 100,
+    limit: DEFAULT_PAGE_SIZE,
+    offset: 0,
+    sortBy: "created_at",
+    sortDirection: "desc",
   });
   const { data: jobs = [], isLoading, error, refetch } = useGetJobsFilteredQuery(appliedFilters);
   const errorMessage =
@@ -128,15 +137,37 @@ export function JobList({ initialFilters, compact = false, onJobClick }: JobList
         : null;
 
   const handleApplyFilters = () => {
-    setAppliedFilters(draftFilters);
+    setPage(0);
+    setAppliedFilters({ ...draftFilters, limit: pageSize, offset: 0, sortBy, sortDirection });
     setShowFilters(false);
   };
 
   const handleClearFilters = () => {
-    const clearedFilters = { limit: 100 };
-    setDraftFilters(clearedFilters);
-    setAppliedFilters(clearedFilters);
+    setPage(0);
+    setDraftFilters({ limit: pageSize });
+    setAppliedFilters({ limit: pageSize, offset: 0, sortBy, sortDirection });
     setShowFilters(false);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+    setAppliedFilters((prev) => ({ ...prev, offset: newPage * pageSize }));
+  };
+
+  const handlePageSizeChange = (newSize: number) => {
+    setPageSize(newSize);
+    setPage(0);
+    setAppliedFilters((prev) => ({ ...prev, limit: newSize, offset: 0 }));
+  };
+
+  const handleSort = (key: JobSortKey) => {
+    const newDirection = sortBy === key
+      ? (sortDirection === "asc" ? "desc" : "asc")
+      : "asc";
+    setSortBy(key);
+    setSortDirection(newDirection);
+    setPage(0);
+    setAppliedFilters((prev) => ({ ...prev, sortBy: key, sortDirection: newDirection, offset: 0 }));
   };
 
   const hasActiveFilters = appliedFilters.status || appliedFilters.job_type;
@@ -165,7 +196,7 @@ export function JobList({ initialFilters, compact = false, onJobClick }: JobList
   }
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col h-full min-h-0 gap-4">
       {/* Toolbar */}
       {!compact && (
         <div className="flex items-center justify-between">
@@ -189,11 +220,35 @@ export function JobList({ initialFilters, compact = false, onJobClick }: JobList
               </Button>
             )}
           </div>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">
-              {jobs.length} job{jobs.length !== 1 ? 's' : ''}
-            </span>
-            <Button variant="outline" size="icon" onClick={() => refetch()} disabled={isLoading} aria-label="Refresh jobs">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Select
+                value={String(pageSize)}
+                onValueChange={(v) => handlePageSizeChange(Number(v))}
+              >
+                <SelectTrigger className="h-8 w-[70px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PAGE_SIZE_OPTIONS.map((size) => (
+                    <SelectItem key={size} value={String(size)}>
+                      {size}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <span>per page</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Button variant="outline" size="icon" className="h-8 w-8" disabled={page === 0} onClick={() => handlePageChange(page - 1)}>
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm text-muted-foreground px-2">{page + 1}</span>
+              <Button variant="outline" size="icon" className="h-8 w-8" disabled={jobs.length < pageSize} onClick={() => handlePageChange(page + 1)}>
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+            <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => refetch()} disabled={isLoading} aria-label="Refresh jobs">
               <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
             </Button>
           </div>
@@ -262,17 +317,44 @@ export function JobList({ initialFilters, compact = false, onJobClick }: JobList
           </CardHeader>
         </Card>
       ) : (
-        <div className="border rounded-lg">
-          <Table>
+        <div className="border rounded-lg flex-1 min-h-0 overflow-hidden [&>div]:h-full [&>div]:overflow-auto">
+          <Table className="border-separate border-spacing-0 [&_td]:border-b [&_td]:border-border">
             <TableHeader>
               <TableRow>
-                <TableHead>Status</TableHead>
-                <TableHead>Job Type</TableHead>
-                <TableHead>Namespace / Table</TableHead>
-                <TableHead>Created</TableHead>
-                <TableHead>Duration</TableHead>
-                {!compact && <TableHead>Node</TableHead>}
-                <TableHead className="w-[50px]"></TableHead>
+                {([
+                  ["status", "Status"],
+                  ["job_type", "Job Type"],
+                  [null, "Namespace / Table"],
+                  ["created_at", "Created"],
+                  [null, "Duration"],
+                ] as [JobSortKey | null, string][]).map(([key, label], i) => (
+                  <TableHead
+                    key={key ?? `col-${i}`}
+                    className={`sticky top-0 bg-background z-10 border-b border-border ${key ? "cursor-pointer select-none hover:text-foreground" : ""}`}
+                    onClick={key ? () => handleSort(key) : undefined}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {label}
+                      {key && (sortBy === key
+                        ? (sortDirection === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />)
+                        : <ArrowUpDown className="h-3 w-3 opacity-30" />)}
+                    </span>
+                  </TableHead>
+                ))}
+                {!compact && (
+                  <TableHead
+                    className="sticky top-0 bg-background z-10 border-b border-border cursor-pointer select-none hover:text-foreground"
+                    onClick={() => handleSort("node_id")}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      Node
+                      {sortBy === "node_id"
+                        ? (sortDirection === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />)
+                        : <ArrowUpDown className="h-3 w-3 opacity-30" />}
+                    </span>
+                  </TableHead>
+                )}
+                <TableHead className="sticky top-0 bg-background z-10 border-b border-border w-[50px]"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -284,7 +366,7 @@ export function JobList({ initialFilters, compact = false, onJobClick }: JobList
                 >
                   <TableCell>
                     <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(job.status)}`}>
-                      {STATUS_ICONS[job.status]}
+                      {STATUS_ICONS[job.status.charAt(0).toUpperCase() + job.status.slice(1).toLowerCase()] || STATUS_ICONS[job.status]}
                       {job.status}
                     </span>
                   </TableCell>
@@ -339,7 +421,7 @@ export function JobList({ initialFilters, compact = false, onJobClick }: JobList
               Job Details
               {selectedJob && (
                 <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(selectedJob.status)}`}>
-                  {STATUS_ICONS[selectedJob.status]}
+                  {STATUS_ICONS[selectedJob.status.charAt(0).toUpperCase() + selectedJob.status.slice(1).toLowerCase()] || STATUS_ICONS[selectedJob.status]}
                   {selectedJob.status}
                 </span>
               )}

--- a/ui/src/lib/formatters.ts
+++ b/ui/src/lib/formatters.ts
@@ -321,3 +321,7 @@ export function formatCellValue(
   // Default: string
   return { formatted: String(value), isTimestamp: false, isNull: false };
 }
+
+export function formatUtcTimestamp(value: number | string | null | undefined): string {
+  return formatTimestamp(value, undefined, "iso8601-datetime", "utc");
+}

--- a/ui/src/pages/Jobs.tsx
+++ b/ui/src/pages/Jobs.tsx
@@ -6,6 +6,8 @@ export default function Jobs() {
     <PageLayout
       title="Jobs"
       description="View and monitor background jobs in the system"
+      className="flex flex-col h-full min-h-0 gap-6"
+      contentClassName="flex-1 min-h-0 flex flex-col gap-4"
     >
       <JobList />
     </PageLayout>

--- a/ui/src/pages/Logging.tsx
+++ b/ui/src/pages/Logging.tsx
@@ -65,7 +65,7 @@ export default function Logging() {
       </div>
 
       {/* Tab Content */}
-      <div className="flex-1 p-4 lg:p-6">
+      <div className="flex-1 min-h-0 p-4 lg:p-6">
         {renderContent()}
       </div>
     </div>

--- a/ui/src/pages/StreamingTopics.tsx
+++ b/ui/src/pages/StreamingTopics.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { RefreshCw, Search, ArrowRight } from "lucide-react";
+import { RefreshCw, Search, ArrowRight, ArrowUp, ArrowDown, ArrowUpDown } from "lucide-react";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { StreamingTabs } from "@/features/streaming/components/StreamingTabs";
 import { useGetStreamingTopicsQuery } from "@/store/apiSlice";
@@ -16,14 +16,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { formatTimestamp } from "@/lib/formatters";
+import { formatUtcTimestamp } from "@/lib/formatters";
 
-function formatNullableTimestamp(value: string | null): string {
-  if (!value) {
-    return "-";
-  }
-  return formatTimestamp(value, undefined, "iso8601-datetime", "utc");
-}
+type SortKey = "topicId" | "partitions" | "routeCount" | "retentionSeconds" | "updatedAt";
+type SortDirection = "asc" | "desc";
 
 function formatNullableNumber(value: number | null): string {
   if (value === null || value === undefined) {
@@ -41,6 +37,16 @@ export default function StreamingTopics() {
     refetch,
   } = useGetStreamingTopicsQuery();
   const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("topicId");
+  const [directions, setDirections] = useState<Record<SortKey, SortDirection>>({
+    topicId: "desc",
+    partitions: "desc",
+    routeCount: "desc",
+    retentionSeconds: "desc",
+    updatedAt: "desc",
+  });
+  const sortDirection = directions[sortKey];
+  const [sortedTopics, setSortedTopics] = useState<typeof topics>([]);
 
   const filteredTopics = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -53,6 +59,34 @@ export default function StreamingTopics() {
         topic.name.toLowerCase().includes(query),
     );
   }, [search, topics]);
+
+  useEffect(() => {
+    setSortedTopics(filteredTopics);
+  }, [filteredTopics]);
+
+  const applySort = (data: typeof topics, key: SortKey, direction: SortDirection) => {
+    const dir = direction === "desc" ? -1 : 1;
+    return [...data].sort((a, b) => {
+      const aVal = a[key];
+      const bVal = b[key];
+      if (aVal === null || aVal === undefined) return 1;
+      if (bVal === null || bVal === undefined) return -1;
+      if (typeof aVal === "string" && typeof bVal === "string") {
+        return aVal.localeCompare(bVal) * dir;
+      }
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return (aVal - bVal) * dir;
+      }
+      return 0;
+    });
+  };
+
+  const handleSort = (key: SortKey) => {
+    const newDirection = directions[key] === "asc" ? "desc" : "asc";
+    setSortKey(key);
+    setDirections((prev) => ({ ...prev, [key]: newDirection }));
+    setSortedTopics((prev) => applySort(prev, key, newDirection));
+  };
 
   const errorMessage =
     error && "error" in error && typeof error.error === "string"
@@ -94,7 +128,7 @@ export default function StreamingTopics() {
         <CardHeader className="pb-2">
           <CardTitle className="text-base">Topics</CardTitle>
           <CardDescription>
-            {filteredTopics.length} topic{filteredTopics.length === 1 ? "" : "s"} visible
+            {sortedTopics.length} topic{sortedTopics.length === 1 ? "" : "s"} visible
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -102,29 +136,44 @@ export default function StreamingTopics() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Topic</TableHead>
-                  <TableHead>Partitions</TableHead>
-                  <TableHead>Routes</TableHead>
-                  <TableHead>Retention (sec)</TableHead>
-                  <TableHead>Updated</TableHead>
+                  {([
+                    ["topicId", "Topic"],
+                    ["partitions", "Partitions"],
+                    ["routeCount", "Routes"],
+                    ["retentionSeconds", "Retention (sec)"],
+                    ["updatedAt", "Updated"],
+                  ] as [SortKey, string][]).map(([key, label]) => (
+                    <TableHead
+                      key={key}
+                      className="cursor-pointer select-none hover:text-foreground"
+                      onClick={() => handleSort(key)}
+                    >
+                      <span className="inline-flex items-center gap-1">
+                        {label}
+                        {sortKey === key
+                          ? (sortDirection === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />)
+                          : <ArrowUpDown className="h-3 w-3 opacity-30" />}
+                      </span>
+                    </TableHead>
+                  ))}
                   <TableHead className="w-[170px]">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredTopics.length === 0 ? (
+                {sortedTopics.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
                       {search.trim() ? "No topics match your search." : "No topics found."}
                     </TableCell>
                   </TableRow>
                 ) : (
-                  filteredTopics.map((topic) => (
+                  sortedTopics.map((topic) => (
                     <TableRow key={topic.topicId}>
                       <TableCell className="font-mono text-xs">{topic.topicId}</TableCell>
                       <TableCell>{topic.partitions}</TableCell>
                       <TableCell>{topic.routeCount}</TableCell>
                       <TableCell>{formatNullableNumber(topic.retentionSeconds)}</TableCell>
-                      <TableCell className="font-mono text-xs">{formatNullableTimestamp(topic.updatedAt)}</TableCell>
+                      <TableCell className="font-mono text-xs">{formatUtcTimestamp(topic.updatedAt)}</TableCell>
                       <TableCell>
                         <div className="flex items-center gap-2">
                           <Button

--- a/ui/src/services/auditLogService.ts
+++ b/ui/src/services/auditLogService.ts
@@ -2,6 +2,7 @@ import { executeSql } from "@/lib/kalam-client";
 import {
   buildAuditLogsQuery,
   type AuditLogFilters,
+  type AuditLogSortKey,
 } from "@/services/sql/queries/auditLogQueries";
 
 export interface AuditLog {
@@ -15,7 +16,7 @@ export interface AuditLog {
   ip_address: string | null;
 }
 
-export type { AuditLogFilters };
+export type { AuditLogFilters, AuditLogSortKey };
 
 export async function fetchAuditLogs(filters?: AuditLogFilters): Promise<AuditLog[]> {
   const rows = await executeSql(buildAuditLogsQuery(filters));

--- a/ui/src/services/sql/queries/auditLogQueries.ts
+++ b/ui/src/services/sql/queries/auditLogQueries.ts
@@ -1,3 +1,5 @@
+export type AuditLogSortKey = "timestamp" | "actor_username" | "action" | "target" | "ip_address";
+
 export interface AuditLogFilters {
   username?: string;
   action?: string;
@@ -5,6 +7,9 @@ export interface AuditLogFilters {
   startDate?: string;
   endDate?: string;
   limit?: number;
+  offset?: number;
+  sortBy?: AuditLogSortKey;
+  sortDirection?: "asc" | "desc";
 }
 
 function escapeSqlLiteral(value: string): string {
@@ -43,10 +48,21 @@ export function buildAuditLogsSubscriptionQuery(filters?: AuditLogFilters): stri
   return `${buildAuditLogsSelect()}${buildAuditLogsWhereClause(filters)}`;
 }
 
+const VALID_SORT_COLUMNS = new Set<AuditLogSortKey>([
+  "timestamp", "actor_username", "action", "target", "ip_address",
+]);
+
 export function buildAuditLogsQuery(filters?: AuditLogFilters): string {
   let sql = buildAuditLogsSubscriptionQuery(filters);
 
-  sql += " ORDER BY timestamp DESC";
+  const sortCol = filters?.sortBy && VALID_SORT_COLUMNS.has(filters.sortBy)
+    ? filters.sortBy
+    : "timestamp";
+  const sortDir = filters?.sortDirection === "asc" ? "ASC" : "DESC";
+  sql += ` ORDER BY ${sortCol} ${sortDir}`;
   sql += ` LIMIT ${filters?.limit ?? 1000}`;
+  if (filters?.offset) {
+    sql += ` OFFSET ${filters.offset}`;
+  }
   return sql;
 }

--- a/ui/src/services/sql/queries/jobQueries.ts
+++ b/ui/src/services/sql/queries/jobQueries.ts
@@ -1,7 +1,12 @@
+export type JobSortKey = "created_at" | "job_type" | "status" | "started_at" | "finished_at" | "node_id";
+
 export interface JobFilters {
   status?: string;
   job_type?: string;
   limit?: number;
+  offset?: number;
+  sortBy?: JobSortKey;
+  sortDirection?: "asc" | "desc";
 }
 
 function escapeSqlLiteral(value: string): string {
@@ -27,7 +32,13 @@ export function buildSystemJobsQuery(filters?: JobFilters): string {
     sql += ` WHERE ${conditions.join(" AND ")}`;
   }
 
-  sql += " ORDER BY created_at DESC";
+  const validSortColumns = new Set<JobSortKey>(["created_at", "job_type", "status", "started_at", "finished_at", "node_id"]);
+  const sortCol = filters?.sortBy && validSortColumns.has(filters.sortBy) ? filters.sortBy : "created_at";
+  const sortDir = filters?.sortDirection === "asc" ? "ASC" : "DESC";
+  sql += ` ORDER BY ${sortCol} ${sortDir}`;
   sql += ` LIMIT ${filters?.limit ?? 1000}`;
+  if (filters?.offset) {
+    sql += ` OFFSET ${filters.offset}`;
+  }
   return sql;
 }


### PR DESCRIPTION
Table improvements across three pages:

**Audit Logs**
- Server-side pagination with page size selector (25/50/100/200)
- Server-side column sorting (timestamp, user, action, target, IP)
- Sticky column headers
- Fixed timestamp display (was showing "Invalid Date")
- Shared `formatUtcTimestamp` utility replacing inline formatting

**Jobs**
- Same pagination and sorting pattern
- Fixed status colors not matching (backend returns lowercase "completed", color map expected "Completed")
- Viewport-filling table layout

**Streaming Topics**
- Client-side column sorting with direction memory per column
- Stable sort stacking (equal values preserve previous sort order)
- Switched to shared `formatUtcTimestamp`

9 files changed.