### PR TITLE
Use table PKs for topic keys; add client reconnect

### DIFF
--- a/backend/crates/kalamdb-core/src/app_context.rs
+++ b/backend/crates/kalamdb-core/src/app_context.rs
@@ -22,7 +22,8 @@ use kalamdb_commons::{constants::ColumnFamilyNames, NodeId};
 use kalamdb_configs::ServerConfig;
 use kalamdb_filestore::StorageRegistry;
 use kalamdb_live::{
-    ConnectionsManager, LiveQueryManager, NotificationService, TopicPublisherService,
+    ConnectionsManager, LiveQueryManager, NotificationService, TopicPrimaryKeyLookup,
+    TopicPublisherService,
 };
 use kalamdb_pg::{KalamPgService, LivePgTransaction};
 use kalamdb_raft::CommandExecutor;
@@ -38,6 +39,36 @@ use std::time::{Duration, Instant};
 
 use crate::metrics::runtime::collect_runtime_metrics;
 use crate::schema_registry::TablesSchemaRegistryAdapter;
+
+struct SchemaRegistryTopicPrimaryKeyLookup {
+    schema_registry: Arc<SchemaRegistry>,
+}
+
+impl SchemaRegistryTopicPrimaryKeyLookup {
+    fn new(schema_registry: Arc<SchemaRegistry>) -> Self {
+        Self { schema_registry }
+    }
+}
+
+impl TopicPrimaryKeyLookup for SchemaRegistryTopicPrimaryKeyLookup {
+    fn primary_key_columns(
+        &self,
+        table_id: &kalamdb_commons::models::TableId,
+    ) -> kalamdb_commons::errors::Result<Vec<String>> {
+        let table_def = self.schema_registry.get_table_if_exists(table_id).map_err(|error| {
+            kalamdb_commons::errors::CommonError::Internal(format!(
+                "Failed to load table definition for {}: {}",
+                table_id, error
+            ))
+        })?;
+
+        Ok(table_def
+            .map(|definition| {
+                definition.get_primary_key_columns().into_iter().map(str::to_owned).collect()
+            })
+            .unwrap_or_default())
+    }
+}
 
 // Use RwLock instead of OnceLock to allow resetting in tests
 // The RwLock is wrapped in a OnceLock for lazy initialization
@@ -438,10 +469,15 @@ impl AppContext {
 
             // Create unified topic publisher service for pub/sub infrastructure
             let visibility_timeout = Duration::from_secs(config.topics.visibility_timeout_secs);
-            let topic_publisher = Arc::new(TopicPublisherService::with_visibility_timeout(
-                storage_backend.clone(),
-                visibility_timeout,
-            ));
+            let topic_primary_key_lookup: Arc<dyn TopicPrimaryKeyLookup> =
+                Arc::new(SchemaRegistryTopicPrimaryKeyLookup::new(schema_registry.clone()));
+            let topic_publisher = Arc::new(
+                TopicPublisherService::with_visibility_timeout_and_primary_key_lookup(
+                    storage_backend.clone(),
+                    visibility_timeout,
+                    Some(topic_primary_key_lookup),
+                ),
+            );
 
             // Create the shared committed snapshot tracker used by the transaction coordinator
             let commit_sequence_tracker = Arc::new(CommitSequenceTracker::new(0));
@@ -833,10 +869,15 @@ impl AppContext {
 
         // Create unified topic publisher service for tests
         let visibility_timeout = Duration::from_secs(config.topics.visibility_timeout_secs);
-        let topic_publisher = Arc::new(TopicPublisherService::with_visibility_timeout(
-            storage_backend.clone(),
-            visibility_timeout,
-        ));
+        let topic_primary_key_lookup: Arc<dyn TopicPrimaryKeyLookup> =
+            Arc::new(SchemaRegistryTopicPrimaryKeyLookup::new(schema_registry.clone()));
+        let topic_publisher = Arc::new(
+            TopicPublisherService::with_visibility_timeout_and_primary_key_lookup(
+                storage_backend.clone(),
+                visibility_timeout,
+                Some(topic_primary_key_lookup),
+            ),
+        );
 
         // Create transaction snapshot tracker for tests
         let commit_sequence_tracker = Arc::new(CommitSequenceTracker::new(0));

--- a/backend/crates/kalamdb-live/src/lib.rs
+++ b/backend/crates/kalamdb-live/src/lib.rs
@@ -50,4 +50,4 @@ pub use fanout::{
 };
 
 // Re-export from kalamdb-publisher crate
-pub use kalamdb_publisher::{TopicCacheStats, TopicPublisherService};
+pub use kalamdb_publisher::{TopicCacheStats, TopicPrimaryKeyLookup, TopicPublisherService};

--- a/backend/crates/kalamdb-publisher/src/lib.rs
+++ b/backend/crates/kalamdb-publisher/src/lib.rs
@@ -26,4 +26,4 @@ mod routing;
 mod service;
 
 pub use models::TopicCacheStats;
-pub use service::TopicPublisherService;
+pub use service::{TopicPrimaryKeyLookup, TopicPublisherService};

--- a/backend/crates/kalamdb-publisher/src/payload.rs
+++ b/backend/crates/kalamdb-publisher/src/payload.rs
@@ -21,13 +21,11 @@ use kalamdb_system::providers::topics::TopicRoute;
 pub(crate) struct PreparedRow {
     /// Pre-serialized payload bytes for Key mode.
     key_payload: Vec<u8>,
+    /// Cached JSON map for primary-key extraction without reserializing the row.
+    json_map: std::collections::HashMap<String, KalamCellValue>,
     /// Pre-serialized payload bytes for Full/Diff mode (with `_table` already injected).
     /// Only `Some` when `from_row_with_table` is used.
     full_payload: Option<Vec<u8>>,
-    /// Cached JSON string for key/hash operations.
-    json_string: String,
-    /// Whether the row was empty (no values).
-    is_empty: bool,
     /// Pre-computed hash for partition selection.
     partition_hash: u64,
 }
@@ -37,23 +35,14 @@ impl PreparedRow {
     pub fn from_row(row: &Row) -> Result<Self> {
         let json_map = row_to_json_map(row)
             .map_err(|e| CommonError::Internal(format!("Failed to convert row to JSON: {}", e)))?;
-        let is_empty = json_map.is_empty();
         let key_payload = serde_json::to_vec(&json_map)
             .map_err(|e| CommonError::Internal(format!("Failed to serialize keys: {}", e)))?;
         // SAFETY: serde_json::to_vec() always produces valid UTF-8 JSON bytes.
-        let json_string = unsafe { String::from_utf8_unchecked(key_payload.clone()) };
-        let partition_hash = {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::{Hash, Hasher};
-            let mut hasher = DefaultHasher::new();
-            json_string.hash(&mut hasher);
-            hasher.finish()
-        };
+        let partition_hash = hash_key(unsafe { std::str::from_utf8_unchecked(&key_payload) });
         Ok(Self {
             key_payload,
+            json_map,
             full_payload: None,
-            json_string,
-            is_empty,
             partition_hash,
         })
     }
@@ -65,27 +54,19 @@ impl PreparedRow {
     pub fn from_row_with_table(row: &Row, table_id: &TableId) -> Result<Self> {
         let mut json_map = row_to_json_map(row)
             .map_err(|e| CommonError::Internal(format!("Failed to convert row to JSON: {}", e)))?;
-        let is_empty = json_map.is_empty();
         let key_payload = serde_json::to_vec(&json_map)
             .map_err(|e| CommonError::Internal(format!("Failed to serialize keys: {}", e)))?;
         // SAFETY: serde_json::to_vec() always produces valid UTF-8 JSON bytes.
-        let json_string = unsafe { String::from_utf8_unchecked(key_payload.clone()) };
-        let partition_hash = {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::{Hash, Hasher};
-            let mut hasher = DefaultHasher::new();
-            json_string.hash(&mut hasher);
-            hasher.finish()
-        };
+        let partition_hash = hash_key(unsafe { std::str::from_utf8_unchecked(&key_payload) });
         // Pre-insert _table and serialize for Full/Diff payloads.
         json_map.insert("_table".to_string(), KalamCellValue::text(table_id.to_string()));
         let full_payload = serde_json::to_vec(&json_map)
             .map_err(|e| CommonError::Internal(format!("Failed to serialize row: {}", e)))?;
+        json_map.remove("_table");
         Ok(Self {
             key_payload,
+            json_map,
             full_payload: Some(full_payload),
-            json_string,
-            is_empty,
             partition_hash,
         })
     }
@@ -119,14 +100,10 @@ impl PreparedRow {
         }
     }
 
-    /// Extract a message key from the pre-computed JSON.
+    /// Extract a message key from the cached primary-key columns.
     #[inline]
-    pub fn extract_key(&self) -> Option<String> {
-        if self.is_empty {
-            None
-        } else {
-            Some(self.json_string.clone())
-        }
+    pub fn extract_key(&self, primary_key_columns: &[String]) -> Result<Option<String>> {
+        extract_primary_key(&self.json_map, primary_key_columns)
     }
 
     /// Hash the row for consistent partition selection using the cached hash.
@@ -151,36 +128,26 @@ pub(crate) fn extract_payload(
     }
 }
 
-/// Extract a message key from a Row (for keyed/partitioned topics).
-pub(crate) fn extract_key(row: &Row) -> Result<Option<String>> {
-    // TODO: Add partition_key_expr support
-    if row.values.is_empty() {
-        return Ok(None);
-    }
-
+/// Extract a message key from a Row using the table primary key columns.
+pub(crate) fn extract_key(row: &Row, primary_key_columns: &[String]) -> Result<Option<String>> {
     let json_map = row_to_json_map(row)
         .map_err(|e| CommonError::Internal(format!("Failed to convert row to JSON: {}", e)))?;
 
-    let json_str = serde_json::to_string(&json_map)
-        .map_err(|e| CommonError::Internal(format!("Failed to serialize key: {}", e)))?;
-
-    Ok(Some(json_str))
+    extract_primary_key(&json_map, primary_key_columns)
 }
 
 /// Hash a row for consistent partition selection.
 pub(crate) fn hash_row(row: &Row) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-
     // Hash the JSON representation for consistency
     if let Ok(json_map) = row_to_json_map(row) {
         if let Ok(json_str) = serde_json::to_string(&json_map) {
-            json_str.hash(&mut hasher);
-            return hasher.finish();
+            return hash_key(&json_str);
         }
     }
+
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
 
     // Fallback: hash column names only
     for key in row.values.keys() {
@@ -190,7 +157,50 @@ pub(crate) fn hash_row(row: &Row) -> u64 {
     hasher.finish()
 }
 
+/// Hash a serialized topic key using the same stable hash as partition selection.
+pub(crate) fn hash_key(key: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
 // ---- Internal helpers ----
+
+fn extract_primary_key(
+    json_map: &std::collections::HashMap<String, KalamCellValue>,
+    primary_key_columns: &[String],
+) -> Result<Option<String>> {
+    if primary_key_columns.is_empty() {
+        return Ok(None);
+    }
+
+    if primary_key_columns.len() == 1 {
+        let column = &primary_key_columns[0];
+        let value = json_map.get(column).ok_or_else(|| {
+            CommonError::InvalidInput(format!("Row missing primary key column '{}'", column))
+        })?;
+
+        return Ok(Some(match value.as_str() {
+            Some(text) => text.to_string(),
+            None => value.to_string(),
+        }));
+    }
+
+    let mut key_map = std::collections::BTreeMap::new();
+    for column in primary_key_columns {
+        let value = json_map.get(column).ok_or_else(|| {
+            CommonError::InvalidInput(format!("Row missing primary key column '{}'", column))
+        })?;
+        key_map.insert(column.as_str(), value);
+    }
+
+    serde_json::to_string(&key_map)
+        .map(Some)
+        .map_err(|e| CommonError::Internal(format!("Failed to serialize key: {}", e)))
+}
 
 fn extract_key_columns(row: &Row) -> Result<Vec<u8>> {
     if row.values.is_empty() {

--- a/backend/crates/kalamdb-publisher/src/service.rs
+++ b/backend/crates/kalamdb-publisher/src/service.rs
@@ -28,6 +28,12 @@ use crate::offset::OffsetAllocator;
 use crate::payload;
 use crate::routing::RouteCache;
 
+/// Lookup primary-key columns for a table so topic keys can be derived from
+/// stable row identity instead of the full row payload.
+pub trait TopicPrimaryKeyLookup: Send + Sync {
+    fn primary_key_columns(&self, table_id: &TableId) -> Result<Vec<String>>;
+}
+
 /// Default visibility timeout for pending claims.
 ///
 /// If a consumer fetches messages but does not ack within this window, the
@@ -146,6 +152,8 @@ pub struct TopicPublisherService {
     offset_store: Arc<TopicOffsetsTableProvider>,
     /// In-memory route cache: TableId → routes.
     route_cache: RouteCache,
+    /// Schema-backed lookup for deriving stable topic keys from table primary keys.
+    primary_key_lookup: Option<Arc<dyn TopicPrimaryKeyLookup>>,
     /// Atomic per-topic-partition offset counters.
     offset_allocator: OffsetAllocator,
     /// In-memory per-(topic, group, partition) claim state used to avoid
@@ -161,13 +169,31 @@ pub struct TopicPublisherService {
 impl TopicPublisherService {
     /// Create a new TopicPublisherService with stores backed by the given storage.
     pub fn new(storage_backend: Arc<dyn StorageBackend>) -> Self {
-        Self::with_visibility_timeout(storage_backend, DEFAULT_VISIBILITY_TIMEOUT)
+        Self::with_visibility_timeout_and_primary_key_lookup(
+            storage_backend,
+            DEFAULT_VISIBILITY_TIMEOUT,
+            None,
+        )
     }
 
     /// Create a new TopicPublisherService with a custom visibility timeout.
     pub fn with_visibility_timeout(
         storage_backend: Arc<dyn StorageBackend>,
         visibility_timeout: Duration,
+    ) -> Self {
+        Self::with_visibility_timeout_and_primary_key_lookup(
+            storage_backend,
+            visibility_timeout,
+            None,
+        )
+    }
+
+    /// Create a new TopicPublisherService with a custom visibility timeout and
+    /// an optional primary-key lookup for deriving stable topic keys.
+    pub fn with_visibility_timeout_and_primary_key_lookup(
+        storage_backend: Arc<dyn StorageBackend>,
+        visibility_timeout: Duration,
+        primary_key_lookup: Option<Arc<dyn TopicPrimaryKeyLookup>>,
     ) -> Self {
         // Ensure the topic message partition exists.
         // Consumer offsets live in system.topic_offsets (system_topic_offsets CF),
@@ -183,10 +209,18 @@ impl TopicPublisherService {
             message_store,
             offset_store,
             route_cache: RouteCache::new(),
+            primary_key_lookup,
             offset_allocator: OffsetAllocator::new(),
             group_claim_state: DashMap::new(),
             partition_write_locks: DashMap::new(),
             visibility_timeout,
+        }
+    }
+
+    fn primary_key_columns_for(&self, table_id: &TableId) -> Result<Vec<String>> {
+        match &self.primary_key_lookup {
+            Some(lookup) => lookup.primary_key_columns(table_id),
+            None => Ok(Vec::new()),
         }
     }
 
@@ -278,6 +312,7 @@ impl TopicPublisherService {
         if matching.is_empty() {
             return Ok(0);
         }
+        let primary_key_columns = self.primary_key_columns_for(table_id)?;
 
         let mut total_published = 0;
 
@@ -294,15 +329,11 @@ impl TopicPublisherService {
             let payload_bytes = payload::extract_payload(&entry.route, row, table_id)?;
 
             // Extract message key (optional).
-            let key = payload::extract_key(row)?;
+            let key = payload::extract_key(row, &primary_key_columns)?;
 
             // Select partition.
             let partition_id = if let Some(ref k) = key {
-                use std::collections::hash_map::DefaultHasher;
-                use std::hash::{Hash, Hasher};
-                let mut hasher = DefaultHasher::new();
-                k.hash(&mut hasher);
-                (hasher.finish() % entry.topic_partitions as u64) as u32
+                (payload::hash_key(k) % entry.topic_partitions as u64) as u32
             } else {
                 (payload::hash_row(row) % entry.topic_partitions as u64) as u32
             };
@@ -392,6 +423,7 @@ impl TopicPublisherService {
         if matching.is_empty() {
             return Ok(0);
         }
+        let primary_key_columns = self.primary_key_columns_for(table_id)?;
 
         // Check if any route uses Full/Diff mode (needs _table injection).
         let needs_full_payload = matching.iter().any(|e| {
@@ -414,6 +446,11 @@ impl TopicPublisherService {
                 .collect::<Result<Vec<_>>>()?
         };
 
+        let prepared_keys: Vec<Option<String>> = prepared
+            .iter()
+            .map(|prep| prep.extract_key(&primary_key_columns))
+            .collect::<Result<Vec<_>>>()?;
+
         let mut total_published = 0;
         let timestamp_ms = chrono::Utc::now().timestamp_millis();
 
@@ -423,7 +460,11 @@ impl TopicPublisherService {
                 std::collections::HashMap::new();
 
             for (idx, prep) in prepared.iter().enumerate() {
-                let partition_id = (prep.hash_row() % entry.topic_partitions as u64) as u32;
+                let partition_hash = match prepared_keys[idx].as_deref() {
+                    Some(key) => payload::hash_key(key),
+                    None => prep.hash_row(),
+                };
+                let partition_id = (partition_hash % entry.topic_partitions as u64) as u32;
                 partition_groups.entry(partition_id).or_default().push(idx);
             }
 
@@ -434,18 +475,17 @@ impl TopicPublisherService {
 
                 // Pre-extract payloads and keys OUTSIDE the lock to minimize
                 // lock hold time. Serialization is the expensive part.
-                let mut pre_encoded: Vec<(Vec<u8>, Vec<u8>)> =
+                let mut pre_encoded: Vec<(Vec<u8>, Option<String>)> =
                     Vec::with_capacity(row_indices.len());
                 for &row_idx in row_indices {
                     let prep = &prepared[row_idx];
                     let payload_bytes = prep.extract_payload(&entry.route, table_id)?;
-                    let key = prep.extract_key();
+                    let key = prepared_keys[row_idx].clone();
 
                     // We'll fill in the actual offset inside the lock.
                     // For now, pre-encode everything except offset-dependent fields.
                     // Store (payload_bytes, key) temporarily.
-                    let key_bytes = key.map(|k| k.into_bytes()).unwrap_or_default();
-                    pre_encoded.push((payload_bytes, key_bytes));
+                    pre_encoded.push((payload_bytes, key));
                 }
 
                 // Acquire partition lock only for offset allocation + RocksDB write.
@@ -463,15 +503,8 @@ impl TopicPublisherService {
 
                 // Now build messages with real offsets and serialize them.
                 let mut raw_entries = Vec::with_capacity(pre_encoded.len());
-                for (i, (payload_bytes, key_bytes)) in pre_encoded.into_iter().enumerate() {
+                for (i, (payload_bytes, key)) in pre_encoded.into_iter().enumerate() {
                     let offset = start_offset + i as u64;
-                    let key = if key_bytes.is_empty() {
-                        None
-                    } else {
-                        // SAFETY: key_bytes comes from String::into_bytes() via extract_key(),
-                        // which always produces valid UTF-8.
-                        Some(unsafe { String::from_utf8_unchecked(key_bytes) })
-                    };
 
                     let message = TopicMessage::new_with_user(
                         entry.topic_id.clone(),
@@ -724,6 +757,16 @@ mod tests {
     use kalamdb_store::test_utils::InMemoryBackend;
     use kalamdb_system::providers::topics::TopicRoute;
 
+    struct FixedPrimaryKeyLookup {
+        columns: Vec<String>,
+    }
+
+    impl TopicPrimaryKeyLookup for FixedPrimaryKeyLookup {
+        fn primary_key_columns(&self, _table_id: &TableId) -> Result<Vec<String>> {
+            Ok(self.columns.clone())
+        }
+    }
+
     fn create_test_row(id: i32, name: &str) -> Row {
         let mut values = std::collections::BTreeMap::new();
         values.insert("id".to_string(), ScalarValue::Int32(Some(id)));
@@ -732,11 +775,20 @@ mod tests {
     }
 
     fn create_test_topic(topic_id: TopicId, table_id: TableId, op: TopicOp) -> Topic {
+        create_test_topic_with_partitions(topic_id, table_id, op, 2)
+    }
+
+    fn create_test_topic_with_partitions(
+        topic_id: TopicId,
+        table_id: TableId,
+        op: TopicOp,
+        partitions: u32,
+    ) -> Topic {
         Topic {
             topic_id: topic_id.clone(),
             name: format!("topic_{}", topic_id.as_str()),
             alias: None,
-            partitions: 2,
+            partitions,
             retention_seconds: None,
             retention_max_bytes: None,
             routes: vec![TopicRoute {
@@ -749,6 +801,18 @@ mod tests {
             created_at: 0,
             updated_at: 0,
         }
+    }
+
+    fn service_with_primary_key(columns: &[&str]) -> TopicPublisherService {
+        let backend = Arc::new(InMemoryBackend::new());
+        let lookup: Arc<dyn TopicPrimaryKeyLookup> = Arc::new(FixedPrimaryKeyLookup {
+            columns: columns.iter().map(|column| (*column).to_string()).collect(),
+        });
+        TopicPublisherService::with_visibility_timeout_and_primary_key_lookup(
+            backend,
+            Duration::from_secs(60),
+            Some(lookup),
+        )
     }
 
     #[test]
@@ -832,6 +896,71 @@ mod tests {
             all_messages.extend(messages);
         }
         assert_eq!(all_messages.len(), 3);
+    }
+
+    #[test]
+    fn test_publish_uses_primary_key_as_message_key() {
+        let service = service_with_primary_key(&["id"]);
+
+        let ns = NamespaceId::new("test_ns");
+        let table_id = TableId::new(ns.clone(), TableName::from("users"));
+        let topic_id = TopicId::new("pk_topic");
+
+        let topic = create_test_topic(topic_id.clone(), table_id.clone(), TopicOp::Insert);
+        service.add_topic(topic);
+
+        let row = create_test_row(42, "Alice");
+        let published = service.publish_message(&table_id, TopicOp::Insert, &row, None).unwrap();
+        assert_eq!(published, 1);
+
+        let mut messages = Vec::new();
+        for partition_id in 0..2 {
+            messages.extend(service.fetch_messages(&topic_id, partition_id, 0, 10).unwrap());
+        }
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].key.as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn test_batch_publish_same_primary_key_stays_in_one_partition() {
+        let service = service_with_primary_key(&["id"]);
+
+        let ns = NamespaceId::new("test_ns");
+        let table_id = TableId::new(ns.clone(), TableName::from("users"));
+        let topic_id = TopicId::new("pk_batch_topic");
+        let partitions = 32;
+
+        let topic =
+            create_test_topic_with_partitions(topic_id.clone(), table_id.clone(), TopicOp::Insert, partitions);
+        service.add_topic(topic);
+
+        let first = create_test_row(7, "alpha");
+        let second = (0..256)
+            .map(|idx| create_test_row(7, &format!("variant_{}", idx)))
+            .find(|candidate| {
+                payload::hash_row(&first) % partitions as u64
+                    != payload::hash_row(candidate) % partitions as u64
+            })
+            .expect("expected a same-PK row with a different full-row hash partition");
+
+        let published = service
+            .publish_batch(&table_id, TopicOp::Insert, &[first.clone(), second.clone()], None)
+            .unwrap();
+        assert_eq!(published, 2);
+
+        let mut seen_partition_ids = HashSet::new();
+        let mut matching_messages = Vec::new();
+        for partition_id in 0..partitions {
+            for message in service.fetch_messages(&topic_id, partition_id, 0, 10).unwrap() {
+                matching_messages.push(message.clone());
+                seen_partition_ids.insert(message.partition_id);
+            }
+        }
+
+        assert_eq!(matching_messages.len(), 2);
+        assert_eq!(seen_partition_ids.len(), 1, "same PK should hash to the same partition");
+        assert!(matching_messages.iter().all(|message| message.key.as_deref() == Some("7")));
     }
 
     #[test]

--- a/backend/tests/integration_tests/topic_pubsub.rs
+++ b/backend/tests/integration_tests/topic_pubsub.rs
@@ -24,6 +24,7 @@ use serde_json::{json, Value};
 struct HttpConsumeMessage {
     offset: u64,
     partition_id: u32,
+    key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -519,6 +520,28 @@ async fn test_cdc_insert_to_consume_workflow() {
         // is covered by dedicated CDC/topic tests in more controlled setups.
         assert!(first_batch.row_count <= 10, "Unexpected row count: {}", first_batch.row_count);
     }
+
+    let http_server = http_server::get_global_server().await;
+    let auth_header = http_server.bearer_auth_header("root").expect("Failed to create root auth header");
+    let group = format!("cdc-key-check-{}", consolidated_helpers::unique_table("group"));
+    let http_consume = wait_until_group_reads_at_least(
+        http_server,
+        &auth_header,
+        "test_cdc_ns.events_stream",
+        &group,
+        json!("earliest"),
+        10,
+        2,
+    )
+    .await;
+
+    let consumed_keys: std::collections::HashSet<String> = http_consume
+        .messages
+        .iter()
+        .filter_map(|message| message.key.clone())
+        .collect();
+    assert!(consumed_keys.contains("evt1"), "Expected consumed key set to contain evt1");
+    assert!(consumed_keys.contains("evt2"), "Expected consumed key set to contain evt2");
 }
 
 /// Test CONSUME with schema validation

--- a/link/link-common/src/wasm/client.rs
+++ b/link/link-common/src/wasm/client.rs
@@ -433,6 +433,189 @@ fn clear_active_socket(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn schedule_auto_reconnect(
+    connection_options: Rc<RefCell<ConnectionOptions>>,
+    subscription_state: Rc<RefCell<HashMap<String, SubscriptionState>>>,
+    reconnect_attempts: Rc<RefCell<u32>>,
+    is_reconnecting: Rc<RefCell<bool>>,
+    ws_ref: Rc<RefCell<Option<WebSocket>>>,
+    ping_interval_id: Rc<RefCell<i32>>,
+    url: String,
+    auth: WasmAuthProvider,
+    auth_provider_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    on_connect_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    on_disconnect_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    on_error_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    on_receive_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    negotiated_ser: Rc<Cell<SerializationType>>,
+) {
+    let (delay, disable_compression) = {
+        let opts = connection_options.borrow();
+        if !opts.auto_reconnect || *is_reconnecting.borrow() {
+            return;
+        }
+
+        let current_attempts = *reconnect_attempts.borrow();
+        if let Some(max) = opts.max_reconnect_attempts {
+            if current_attempts >= max {
+                wasm_debug_log!(&format!(
+                    "KalamClient: Max reconnection attempts ({}) reached",
+                    max
+                ));
+                emit_runtime_ws_error(&on_error_cb, "Max reconnection attempts reached", false);
+                return;
+            }
+        }
+
+        (
+            std::cmp::min(
+                opts.reconnect_delay_ms * (2u64.pow(current_attempts)),
+                opts.max_reconnect_delay_ms,
+            ),
+            opts.disable_compression,
+        )
+    };
+
+    wasm_debug_log!(&format!(
+        "KalamClient: Scheduling reconnection in {}ms (attempt {})",
+        delay,
+        *reconnect_attempts.borrow() + 1
+    ));
+
+    let reconnect_fn = Closure::wrap(Box::new(move || {
+        {
+            let opts = connection_options.borrow();
+            if !opts.auto_reconnect {
+                return;
+            }
+        }
+
+        if ws_ref.borrow().is_some() {
+            return;
+        }
+
+        *is_reconnecting.borrow_mut() = true;
+        *reconnect_attempts.borrow_mut() += 1;
+
+        let reconnect_url = url.clone();
+        let reconnect_auth = auth.clone();
+        let reconnect_auth_provider = Rc::clone(&auth_provider_cb);
+        let reconnect_connection_options = Rc::clone(&connection_options);
+        let reconnect_subscription_state = Rc::clone(&subscription_state);
+        let reconnect_reconnect_attempts = Rc::clone(&reconnect_attempts);
+        let reconnect_is_reconnecting = Rc::clone(&is_reconnecting);
+        let reconnect_ws_ref = Rc::clone(&ws_ref);
+        let reconnect_ping_interval_id = Rc::clone(&ping_interval_id);
+        let reconnect_on_connect = Rc::clone(&on_connect_cb);
+        let reconnect_on_disconnect = Rc::clone(&on_disconnect_cb);
+        let reconnect_on_error = Rc::clone(&on_error_cb);
+        let reconnect_on_receive = Rc::clone(&on_receive_cb);
+        let reconnect_negotiated_ser = Rc::clone(&negotiated_ser);
+        let next_url = url.clone();
+        let next_auth = auth.clone();
+        let next_auth_provider = Rc::clone(&auth_provider_cb);
+        let next_connection_options = Rc::clone(&connection_options);
+        let next_subscription_state = Rc::clone(&subscription_state);
+        let next_reconnect_attempts = Rc::clone(&reconnect_attempts);
+        let next_is_reconnecting = Rc::clone(&is_reconnecting);
+        let next_ws_ref = Rc::clone(&ws_ref);
+        let next_ping_interval_id = Rc::clone(&ping_interval_id);
+        let next_on_connect = Rc::clone(&on_connect_cb);
+        let next_on_disconnect = Rc::clone(&on_disconnect_cb);
+        let next_on_error = Rc::clone(&on_error_cb);
+        let next_on_receive = Rc::clone(&on_receive_cb);
+        let next_negotiated_ser = Rc::clone(&negotiated_ser);
+
+        wasm_bindgen_futures::spawn_local(async move {
+            match reconnect_internal_with_auth(
+                reconnect_url,
+                reconnect_auth,
+                reconnect_auth_provider.borrow().clone(),
+                disable_compression,
+            )
+            .await
+            {
+                Ok(ws) => {
+                    *reconnect_ws_ref.borrow_mut() = Some(ws.clone());
+                    install_runtime_disconnect_handlers(
+                        &ws,
+                        Rc::clone(&reconnect_subscription_state),
+                        Rc::clone(&reconnect_ws_ref),
+                        Rc::clone(&reconnect_ping_interval_id),
+                        Rc::clone(&reconnect_on_disconnect),
+                        Rc::clone(&reconnect_on_error),
+                    );
+                    install_runtime_message_handler(
+                        &ws,
+                        Rc::clone(&reconnect_subscription_state),
+                        Rc::clone(&reconnect_on_receive),
+                        Rc::clone(&reconnect_negotiated_ser),
+                    );
+                    if let Some(cb) = reconnect_on_connect.borrow().as_ref() {
+                        let _ = cb.call0(&JsValue::NULL);
+                    }
+                    wasm_debug_log!("KalamClient: Reconnection successful");
+                    *reconnect_reconnect_attempts.borrow_mut() = 0;
+                    install_auto_reconnect_listener(
+                        &ws,
+                        Rc::clone(&next_connection_options),
+                        Rc::clone(&reconnect_subscription_state),
+                        Rc::clone(&next_reconnect_attempts),
+                        Rc::clone(&next_is_reconnecting),
+                        Rc::clone(&next_ws_ref),
+                        Rc::clone(&next_ping_interval_id),
+                        next_url,
+                        next_auth,
+                        Rc::clone(&next_auth_provider),
+                        Rc::clone(&next_on_connect),
+                        Rc::clone(&next_on_disconnect),
+                        Rc::clone(&next_on_error),
+                        Rc::clone(&next_on_receive),
+                        Rc::clone(&next_negotiated_ser),
+                    );
+                    resubscribe_all(
+                        Rc::clone(&reconnect_ws_ref),
+                        Rc::clone(&reconnect_subscription_state),
+                        reconnect_negotiated_ser.get(),
+                    )
+                    .await;
+                    reconnect::restart_ping_timer(
+                        &reconnect_ws_ref,
+                        &reconnect_connection_options,
+                        &reconnect_ping_interval_id,
+                        &reconnect_negotiated_ser,
+                    );
+                    *reconnect_is_reconnecting.borrow_mut() = false;
+                },
+                Err(_e) => {
+                    wasm_debug_log!(&format!("KalamClient: Reconnection failed: {:?}", _e));
+                    *reconnect_is_reconnecting.borrow_mut() = false;
+                    schedule_auto_reconnect(
+                        next_connection_options,
+                        next_subscription_state,
+                        next_reconnect_attempts,
+                        next_is_reconnecting,
+                        next_ws_ref,
+                        next_ping_interval_id,
+                        next_url,
+                        next_auth,
+                        next_auth_provider,
+                        next_on_connect,
+                        next_on_disconnect,
+                        next_on_error,
+                        next_on_receive,
+                        next_negotiated_ser,
+                    );
+                },
+            }
+        });
+    }) as Box<dyn FnMut()>);
+
+    super::helpers::global_set_timeout(reconnect_fn.as_ref().unchecked_ref(), delay as i32);
+    reconnect_fn.forget();
+}
+
 fn install_runtime_disconnect_handlers(
     ws: &WebSocket,
     subscriptions: Rc<RefCell<HashMap<String, SubscriptionState>>>,
@@ -1155,6 +1338,15 @@ impl KalamClient {
 
         wasm_debug_log!("KalamClient: WebSocket connection established and authenticated");
 
+        if !self.subscription_state.borrow().is_empty() {
+            resubscribe_all(
+                Rc::clone(&self.ws),
+                Rc::clone(&self.subscription_state),
+                self.negotiated_ser.get(),
+            )
+            .await;
+        }
+
         // Start keepalive ping timer (no-op when interval is 0)
         self.start_ping_timer();
 
@@ -1196,7 +1388,7 @@ impl KalamClient {
     ///
     /// Browser WebSocket APIs do not expose protocol-level Ping frames, so
     /// the WASM client sends a JSON `{"type":"ping"}` message at this
-    /// interval. Set to `0` to disable. Default: 30 000 ms.
+    /// interval. Set to `0` to disable. Default: 5 000 ms.
     ///
     /// The change takes effect on the next `connect()` or reconnect.
     ///
@@ -1867,154 +2059,22 @@ fn install_auto_reconnect_listener(
         if !is_active_socket {
             return;
         }
-
-        let opts = connection_options.borrow();
-        if !opts.auto_reconnect || *is_reconnecting.borrow() {
-            return;
-        }
-
-        let current_attempts = *reconnect_attempts.borrow();
-        if let Some(max) = opts.max_reconnect_attempts {
-            if current_attempts >= max {
-                wasm_debug_log!(&format!(
-                    "KalamClient: Max reconnection attempts ({}) reached",
-                    max
-                ));
-                return;
-            }
-        }
-
-        let delay = std::cmp::min(
-            opts.reconnect_delay_ms * (2u64.pow(current_attempts)),
-            opts.max_reconnect_delay_ms,
+        schedule_auto_reconnect(
+            Rc::clone(&connection_options),
+            Rc::clone(&subscription_state),
+            Rc::clone(&reconnect_attempts),
+            Rc::clone(&is_reconnecting),
+            Rc::clone(&ws_ref),
+            Rc::clone(&ping_interval_id),
+            url.clone(),
+            auth.clone(),
+            Rc::clone(&auth_provider_cb),
+            Rc::clone(&on_connect_cb),
+            Rc::clone(&on_disconnect_cb),
+            Rc::clone(&on_error_cb),
+            Rc::clone(&on_receive_cb),
+            Rc::clone(&negotiated_ser),
         );
-
-        wasm_debug_log!(&format!(
-            "KalamClient: Scheduling reconnection in {}ms (attempt {})",
-            delay,
-            current_attempts + 1
-        ));
-
-        let disable_compression = opts.disable_compression;
-
-        let is_reconnecting_clone = is_reconnecting.clone();
-        let reconnect_attempts_clone = reconnect_attempts.clone();
-        let subscription_state_clone = subscription_state.clone();
-        let ws_ref_clone = ws_ref.clone();
-        let ping_interval_id_clone = ping_interval_id.clone();
-        let connection_options_clone = connection_options.clone();
-        let url_clone = url.clone();
-        let auth_clone = auth.clone();
-        let auth_provider_cb_clone = auth_provider_cb.borrow().clone();
-        let on_connect_clone = on_connect_cb.clone();
-        let on_disconnect_clone = on_disconnect_cb.clone();
-        let on_error_clone = on_error_cb.clone();
-        let on_receive_clone = on_receive_cb.clone();
-        let auth_provider_rc = auth_provider_cb.clone();
-        let negotiated_ser_clone = negotiated_ser.clone();
-
-        let reconnect_fn = Closure::wrap(Box::new(move || {
-            {
-                let opts = connection_options_clone.borrow();
-                if !opts.auto_reconnect {
-                    return;
-                }
-            }
-
-            if ws_ref_clone.borrow().is_some() {
-                return;
-            }
-
-            *is_reconnecting_clone.borrow_mut() = true;
-            *reconnect_attempts_clone.borrow_mut() += 1;
-
-            let url = url_clone.clone();
-            let auth = auth_clone.clone();
-            let next_url = url_clone.clone();
-            let next_auth = auth_clone.clone();
-            let ws_ref = ws_ref_clone.clone();
-            let subscription_state = subscription_state_clone.clone();
-            let is_reconnecting = is_reconnecting_clone.clone();
-            let reconnect_attempts = reconnect_attempts_clone.clone();
-            let ping_id = ping_interval_id_clone.clone();
-            let conn_opts = connection_options_clone.clone();
-            let cb = auth_provider_cb_clone.clone();
-            let on_connect = on_connect_clone.clone();
-            let on_disconnect = on_disconnect_clone.clone();
-            let on_error = on_error_clone.clone();
-            let on_receive = on_receive_clone.clone();
-            let connection_options_next = connection_options_clone.clone();
-            let reconnect_attempts_next = reconnect_attempts_clone.clone();
-            let is_reconnecting_next = is_reconnecting_clone.clone();
-            let ws_ref_next = ws_ref_clone.clone();
-            let ping_id_next = ping_interval_id_clone.clone();
-            let auth_provider_next = auth_provider_rc.clone();
-            let negotiated_ser_inner = negotiated_ser_clone.clone();
-            let negotiated_ser_next = negotiated_ser_clone.clone();
-
-            wasm_bindgen_futures::spawn_local(async move {
-                match reconnect_internal_with_auth(url, auth, cb, disable_compression).await {
-                    Ok(ws) => {
-                        *ws_ref.borrow_mut() = Some(ws.clone());
-                        install_runtime_disconnect_handlers(
-                            &ws,
-                            Rc::clone(&subscription_state),
-                            Rc::clone(&ws_ref),
-                            Rc::clone(&ping_id),
-                            Rc::clone(&on_disconnect),
-                            Rc::clone(&on_error),
-                        );
-                        install_runtime_message_handler(
-                            &ws,
-                            Rc::clone(&subscription_state),
-                            Rc::clone(&on_receive),
-                            Rc::clone(&negotiated_ser_inner),
-                        );
-                        if let Some(cb) = on_connect.borrow().as_ref() {
-                            let _ = cb.call0(&JsValue::NULL);
-                        }
-                        wasm_debug_log!("KalamClient: Reconnection successful");
-                        *reconnect_attempts.borrow_mut() = 0;
-                        install_auto_reconnect_listener(
-                            &ws,
-                            Rc::clone(&connection_options_next),
-                            Rc::clone(&subscription_state),
-                            Rc::clone(&reconnect_attempts_next),
-                            Rc::clone(&is_reconnecting_next),
-                            Rc::clone(&ws_ref_next),
-                            Rc::clone(&ping_id_next),
-                            next_url,
-                            next_auth,
-                            Rc::clone(&auth_provider_next),
-                            Rc::clone(&on_connect),
-                            Rc::clone(&on_disconnect),
-                            Rc::clone(&on_error),
-                            Rc::clone(&on_receive),
-                            Rc::clone(&negotiated_ser_next),
-                        );
-                        resubscribe_all(
-                            ws_ref.clone(),
-                            subscription_state,
-                            negotiated_ser_inner.get(),
-                        )
-                        .await;
-                        reconnect::restart_ping_timer(
-                            &ws_ref,
-                            &conn_opts,
-                            &ping_id,
-                            &negotiated_ser_inner,
-                        );
-                    },
-                    Err(_e) => {
-                        wasm_debug_log!(&format!("KalamClient: Reconnection failed: {:?}", _e));
-                    },
-                }
-                *is_reconnecting.borrow_mut() = false;
-            });
-        }) as Box<dyn FnMut()>);
-
-        super::helpers::global_set_timeout(reconnect_fn.as_ref().unchecked_ref(), delay as i32);
-        reconnect_fn.forget();
     }) as Box<dyn FnMut(CloseEvent)>);
 
     ws.add_event_listener_with_callback("close", onclose_reconnect.as_ref().unchecked_ref())

--- a/link/sdks/typescript/client/src/client.ts
+++ b/link/sdks/typescript/client/src/client.ts
@@ -402,6 +402,16 @@ export class KalamDBClient {
     }
   }
 
+  /**
+   * Explicitly establish or restore the shared WebSocket connection.
+   *
+   * This preserves any stored subscription state in the underlying WASM
+   * client, so reconnecting an existing instance can resume live queries.
+   */
+  async connect(): Promise<void> {
+    await this.connectInternal();
+  }
+
   /** Disconnect and clean up all subscriptions */
   async disconnect(): Promise<void> {
     this.log(LogLevel.Info, 'connection', 'Disconnecting...');

--- a/link/sdks/typescript/client/tests/browser-resume-e2e.html
+++ b/link/sdks/typescript/client/tests/browser-resume-e2e.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KalamDB Browser Resume E2E</title>
+  <style>
+    body {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      background: #111827;
+      color: #e5e7eb;
+      margin: 0;
+      padding: 24px;
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: 28px;
+      color: #f9fafb;
+    }
+
+    p {
+      color: #9ca3af;
+      line-height: 1.5;
+    }
+
+    .card {
+      background: #1f2937;
+      border: 1px solid #374151;
+      border-radius: 14px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+
+    .status.running {
+      background: rgba(59, 130, 246, 0.18);
+      color: #bfdbfe;
+    }
+
+    .status.pass {
+      background: rgba(16, 185, 129, 0.18);
+      color: #a7f3d0;
+    }
+
+    .status.fail {
+      background: rgba(239, 68, 68, 0.18);
+      color: #fecaca;
+    }
+
+    ul {
+      margin: 16px 0 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 10px;
+    }
+
+    li {
+      background: #0f172a;
+      border: 1px solid #1e293b;
+      border-radius: 10px;
+      padding: 10px 12px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Browser Resume E2E</h1>
+    <p>
+      This page verifies that a live subscription survives an unexpected browser-side socket close,
+      then resumes on an explicit <code>connect()</code> using the same client instance.
+    </p>
+    <div class="card">
+      <div id="status" class="status running">Running browser resume check...</div>
+      <ul id="log"></ul>
+    </div>
+  </main>
+
+  <script type="module">
+    import { Auth, LogLevel, createClient } from '../dist/src/index.js';
+
+    const params = new URLSearchParams(window.location.search);
+    const backendUrl = params.get('backend') ?? 'http://127.0.0.1:8082';
+    const user = params.get('user') ?? 'root';
+    const password = params.get('password') ?? '';
+    const namespace = `browser_resume_${Date.now()}`;
+    const table = `${namespace}.events`;
+    const logElement = document.getElementById('log');
+    const statusElement = document.getElementById('status');
+
+    function log(message) {
+      const item = document.createElement('li');
+      item.textContent = message;
+      logElement.appendChild(item);
+    }
+
+    function setStatus(kind, message) {
+      statusElement.className = `status ${kind}`;
+      statusElement.textContent = message;
+    }
+
+    function unwrapCell(value) {
+      if (value && typeof value.asInt === 'function') {
+        return value.asInt();
+      }
+      if (value && typeof value.asString === 'function') {
+        return value.asString();
+      }
+      if (value && typeof value.asSeqId === 'function') {
+        return value.asSeqId().toString();
+      }
+      return value;
+    }
+
+    function extractRows(events) {
+      const rows = [];
+      for (const event of events) {
+        if ((event.type === 'change' || event.type === 'initial_data_batch') && Array.isArray(event.rows)) {
+          rows.push(...event.rows);
+        }
+      }
+      return rows;
+    }
+
+    function hasRowId(events, expectedId) {
+      return extractRows(events).some((row) => unwrapCell(row.id) === expectedId);
+    }
+
+    async function waitFor(predicate, timeoutMs = 10000, intervalMs = 100) {
+      const started = Date.now();
+      while (!predicate()) {
+        if (Date.now() - started > timeoutMs) {
+          throw new Error(`Timed out after ${timeoutMs}ms`);
+        }
+        await new Promise((resolve) => window.setTimeout(resolve, intervalMs));
+      }
+    }
+
+    async function disposeClient(client) {
+      if (!client) {
+        return;
+      }
+      if (typeof client.shutdown === 'function') {
+        await client.shutdown();
+        return;
+      }
+      await client.disconnect();
+    }
+
+    async function main() {
+      const authProvider = async () => Auth.basic(user, password);
+      const client = createClient({
+        url: backendUrl,
+        authProvider,
+        wsLazyConnect: false,
+        pingIntervalMs: 0,
+        logLevel: LogLevel.Debug,
+      });
+      const writer = createClient({
+        url: backendUrl,
+        authProvider,
+        logLevel: LogLevel.Warn,
+      });
+
+      let unsubscribe = null;
+
+      try {
+        log(`Using backend ${backendUrl}`);
+        await client.initialize();
+        await writer.initialize();
+        client.setAutoReconnect(false);
+        log('Initialized reader and writer clients');
+
+        await client.query(`CREATE NAMESPACE IF NOT EXISTS ${namespace}`);
+        await client.query(`CREATE TABLE IF NOT EXISTS ${table} (id INT PRIMARY KEY, payload TEXT) WITH (TYPE='USER')`);
+        log(`Created test table ${table}`);
+
+        const events = [];
+        unsubscribe = await client.subscribe(table, (event) => {
+          events.push(event);
+          log(`event: ${event.type}`);
+        });
+        await waitFor(() => events.some((event) => event.type === 'subscription_ack'));
+        log('Subscription acknowledged');
+
+        await writer.query(`INSERT INTO ${table} (id, payload) VALUES (1, 'before-close')`);
+        await waitFor(() => hasRowId(events, 1));
+        log('Observed pre-close live row');
+
+        log('Waiting for heartbeat timeout to close the idle socket...');
+        await waitFor(() => !client.isConnected(), 12000, 150);
+        log('Socket closed by backend heartbeat timeout');
+
+        const subscriptions = client.getSubscriptions();
+        if (subscriptions.length !== 1) {
+          throw new Error(`Expected preserved subscription state, found ${subscriptions.length}`);
+        }
+        log('Subscription state preserved locally after disconnect');
+
+        await writer.query(`INSERT INTO ${table} (id, payload) VALUES (2, 'during-gap')`);
+        log('Inserted gap row while disconnected');
+
+        const reconnectEventStart = events.length;
+        await client.connect();
+        await waitFor(() => client.isConnected(), 5000, 100);
+        log('Explicit connect() completed on existing client');
+
+        await writer.query(`INSERT INTO ${table} (id, payload) VALUES (3, 'after-reconnect')`);
+        await waitFor(() => {
+          const resumed = events.slice(reconnectEventStart);
+          return hasRowId(resumed, 2) && hasRowId(resumed, 3);
+        }, 10000, 150);
+
+        const resumedRows = events.slice(reconnectEventStart);
+        if (hasRowId(resumedRows, 1)) {
+          throw new Error('Pre-close row replayed after reconnect');
+        }
+
+        log('Observed gap row and new live row after reconnect with no replay');
+        setStatus('pass', 'PASS: browser reconnect resumed the preserved subscription');
+        window.__browserResumeResult = { ok: true, table, backendUrl };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`FAIL: ${message}`);
+        setStatus('fail', `FAIL: ${message}`);
+        window.__browserResumeResult = { ok: false, error: message };
+        throw error;
+      } finally {
+        try {
+          if (unsubscribe) {
+            await unsubscribe();
+          }
+        } catch (_) {
+          // Ignore cleanup failures in the harness.
+        }
+        await disposeClient(writer).catch(() => {});
+        await disposeClient(client).catch(() => {});
+      }
+    }
+
+    main().catch(() => {});
+  </script>
+</body>
+</html>

--- a/link/sdks/typescript/client/tests/sdk-runtime-coverage.test.mjs
+++ b/link/sdks/typescript/client/tests/sdk-runtime-coverage.test.mjs
@@ -24,6 +24,7 @@ function createRuntimeCoverageWasmClient() {
     deleteCalls: [],
     subscribeCalls: [],
     liveSubscribeCalls: [],
+    connectCalls: 0,
     reconnectConfig: {
       autoReconnect: undefined,
       initialDelayMs: undefined,
@@ -41,6 +42,7 @@ function createRuntimeCoverageWasmClient() {
       return connected;
     },
     async connect() {
+      this.connectCalls += 1;
       connected = true;
     },
     async disconnect() {
@@ -357,6 +359,21 @@ test('login refresh and reconnect helpers delegate to wasm client', async () => 
     globalThis.fetch = originalFetch;
     WasmKalamClient.withJwt = originalWithJwt;
   }
+});
+
+test('connect delegates to wasm client and marks the client connected', async () => {
+  const client = createClient({
+    url: 'http://127.0.0.1:8080',
+    authProvider: async () => Auth.jwt('coverage-token'),
+  });
+  const fakeWasmClient = createRuntimeCoverageWasmClient();
+  client.initialized = true;
+  client.wasmClient = fakeWasmClient;
+
+  await client.connect();
+
+  assert.equal(fakeWasmClient.connectCalls, 1);
+  assert.equal(client.isConnected(), true);
 });
 
 test('live uses subscribe fallback when getKey is provided and handles updates/deletes/errors', async () => {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -26,7 +26,7 @@
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@reduxjs/toolkit": "^2.11.2",
-        "@tailwindcss/postcss": "^4.2.2",
+        "@tailwindcss/postcss": "^4.2.4",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -546,7 +546,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -558,7 +557,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -569,7 +567,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -903,7 +900,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2178,7 +2174,9 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.2",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -2187,34 +2185,36 @@
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.4"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.2",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-x64": "4.2.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
       "cpu": [
         "arm64"
       ],
@@ -2228,7 +2228,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.2",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
       "cpu": [
         "arm64"
       ],
@@ -2242,9 +2244,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
       "cpu": [
         "x64"
       ],
@@ -2258,9 +2260,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
       "cpu": [
         "x64"
       ],
@@ -2274,9 +2276,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
       "cpu": [
         "arm"
       ],
@@ -2290,11 +2292,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2306,11 +2311,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2322,11 +2330,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2338,11 +2349,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2354,9 +2368,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -2382,68 +2396,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
       "cpu": [
         "arm64"
       ],
@@ -2457,9 +2413,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
       "cpu": [
         "x64"
       ],
@@ -2473,14 +2429,16 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.2",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
+      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
         "postcss": "^8.5.6",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.4"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -2584,7 +2542,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3723,11 +3680,13 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -4154,6 +4113,8 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -5385,7 +5346,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.2",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -5396,7 +5359,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/ui/src/features/sql-studio/utils/workspaceHelpers.ts
+++ b/ui/src/features/sql-studio/utils/workspaceHelpers.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/sql-studio-v2/shared/types";
 import type { SqlStudioPersistedQueryTab } from "@/components/sql-studio-v2/shared/workspaceState";
 
-export const DEFAULT_SQL = "SELECT * FROM system.namespaces LIMIT 100;";
+export const DEFAULT_SQL = "";
 
 const AUTO_SELECT_LIMIT_SQL_PATTERN = /^\s*(SELECT\s+\*\s+FROM\s+(?:"[^"]+"|[A-Za-z_][\w$]*)\.(?:"[^"]+"|[A-Za-z_][\w$]*))\s+LIMIT\s+100\s*;\s*$/i;
 

--- a/ui/src/lib/backend-status.test.tsx
+++ b/ui/src/lib/backend-status.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockUseAuth,
+  mockProbeBackendReachability,
+  mockConnectWebSocket,
+  mockIsSubscriptionClientConnected,
+  mockSubscribeToClientConnectivity,
+} = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+  mockProbeBackendReachability: vi.fn(),
+  mockConnectWebSocket: vi.fn(),
+  mockIsSubscriptionClientConnected: vi.fn(),
+  mockSubscribeToClientConnectivity: vi.fn(),
+}));
+
+vi.mock("./auth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("./api", () => ({
+  probeBackendReachability: mockProbeBackendReachability,
+}));
+
+vi.mock("./backend-url", () => ({
+  getApiBaseUrl: () => "http://localhost:8080/v1/api",
+  getBackendOrigin: () => "http://localhost:8080",
+}));
+
+vi.mock("./kalam-client", () => ({
+  connectWebSocket: mockConnectWebSocket,
+  isSubscriptionClientConnected: mockIsSubscriptionClientConnected,
+  subscribeToClientConnectivity: mockSubscribeToClientConnectivity,
+}));
+
+import { BackendStatusProvider } from "./backend-status";
+
+describe("BackendStatusProvider", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      accessToken: "jwt-token",
+      isLoading: false,
+    });
+    mockProbeBackendReachability.mockResolvedValue(undefined);
+    mockConnectWebSocket.mockResolvedValue(undefined);
+    mockIsSubscriptionClientConnected.mockReturnValue(false);
+    mockSubscribeToClientConnectivity.mockReturnValue(() => {});
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reconnects the websocket when the tab becomes visible again", async () => {
+    render(
+      <BackendStatusProvider>
+        <div>status</div>
+      </BackendStatusProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockConnectWebSocket).toHaveBeenCalledTimes(1);
+    });
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(mockConnectWebSocket).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => {
+      expect(mockConnectWebSocket).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/ui/src/lib/backend-status.tsx
+++ b/ui/src/lib/backend-status.tsx
@@ -115,10 +115,25 @@ export function BackendStatusProvider({ children }: { children: ReactNode }) {
       setSocketMessage(event.error.message || "WebSocket disconnected.");
     });
 
+    const reconnectVisibleTab = () => {
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+
+      void ensureSocketConnected();
+    };
+
+    document.addEventListener("visibilitychange", reconnectVisibleTab);
+    window.addEventListener("focus", reconnectVisibleTab);
+    window.addEventListener("pageshow", reconnectVisibleTab);
+
     void ensureSocketConnected();
 
     return () => {
       unsubscribeConnectivity();
+      document.removeEventListener("visibilitychange", reconnectVisibleTab);
+      window.removeEventListener("focus", reconnectVisibleTab);
+      window.removeEventListener("pageshow", reconnectVisibleTab);
     };
   }, [accessToken, ensureSocketConnected, isAuthenticated]);
 

--- a/ui/src/lib/kalam-client.ts
+++ b/ui/src/lib/kalam-client.ts
@@ -178,8 +178,16 @@ async function disconnectSdkClient(targetClient: KalamDBClient | null): Promise<
 
 async function initializeSubscriptionClient(jwtToken: string): Promise<KalamDBClient> {
   return queueLifecycle(async () => {
-    if (jwtToken === currentToken && subscriptionClient && isSubscriptionInitialized && subscriptionClient.isConnected()) {
-      debugLog('[kalam-client] Returning existing initialized subscription client');
+    if (jwtToken === currentToken && subscriptionClient && isSubscriptionInitialized) {
+      applySubscriptionClientListeners(subscriptionClient);
+
+      if (!subscriptionClient.isConnected()) {
+        debugLog('[kalam-client] Reconnecting existing subscription client...');
+        await subscriptionClient.connect();
+      } else {
+        debugLog('[kalam-client] Returning existing initialized subscription client');
+      }
+
       return subscriptionClient;
     }
 

--- a/ui/src/pages/SqlStudio.test.tsx
+++ b/ui/src/pages/SqlStudio.test.tsx
@@ -23,6 +23,7 @@ const mockSetClientSendListener = vi.fn();
 const mockUnsubscribe = vi.fn();
 const mockRemoteUnsubscribe = vi.fn();
 const mockSaveSyncedSqlStudioWorkspaceState = vi.fn();
+const mockLoadSyncedSqlStudioWorkspaceState = vi.fn();
 const mockSubscribeToSyncedSqlStudioWorkspaceState = vi.fn();
 const mockRefetchSchemaTree = vi.fn();
 
@@ -88,6 +89,7 @@ vi.mock("@/services/sqlStudioWorkspaceSyncService", () => ({
       updatedAt: "2026-03-27T00:00:00.000Z",
     };
   },
+  loadSyncedSqlStudioWorkspaceState: (...args: unknown[]) => mockLoadSyncedSqlStudioWorkspaceState(...args),
   saveSyncedSqlStudioWorkspaceState: (...args: unknown[]) => mockSaveSyncedSqlStudioWorkspaceState(...args),
   subscribeToSyncedSqlStudioWorkspaceState: (...args: unknown[]) => mockSubscribeToSyncedSqlStudioWorkspaceState(...args),
 }));
@@ -221,7 +223,7 @@ function createTestStore() {
   });
 }
 
-function renderSqlStudio(store = createTestStore()) {
+async function renderSqlStudio(store = createTestStore()) {
   const view = render(
     <Provider store={store}>
       <MemoryRouter>
@@ -231,6 +233,13 @@ function renderSqlStudio(store = createTestStore()) {
       </MemoryRouter>
     </Provider>,
   );
+
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
   return { store, ...view };
 }
 
@@ -267,6 +276,7 @@ describe("SqlStudio page", () => {
     mockSetClientSendListener.mockReset();
     mockUnsubscribe.mockReset();
     mockRemoteUnsubscribe.mockReset();
+    mockLoadSyncedSqlStudioWorkspaceState.mockReset();
     mockSaveSyncedSqlStudioWorkspaceState.mockReset();
     mockSubscribeToSyncedSqlStudioWorkspaceState.mockReset();
     mockRefetchSchemaTree.mockReset();
@@ -313,6 +323,7 @@ describe("SqlStudio page", () => {
       liveCallback = callback;
       return mockUnsubscribe;
     });
+    mockLoadSyncedSqlStudioWorkspaceState.mockResolvedValue(null);
     mockSaveSyncedSqlStudioWorkspaceState.mockResolvedValue(undefined);
     mockSubscribeToSyncedSqlStudioWorkspaceState.mockImplementation(async (_username: string, callback: (workspace: Record<string, unknown> | null) => void) => {
       syncedWorkspaceCallback = callback;
@@ -350,7 +361,7 @@ describe("SqlStudio page", () => {
       logs: [],
     });
 
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name FROM default.events" },
@@ -362,6 +373,23 @@ describe("SqlStudio page", () => {
     });
 
     expect(await screen.findByText("Ada")).toBeTruthy();
+  });
+
+  it("starts with an empty query editor and opens new tabs empty", async () => {
+    const { store } = await renderSqlStudio();
+
+    expect((getSqlEditor() as HTMLTextAreaElement).value).toBe("");
+
+    fireEvent.click(screen.getByTitle("New query tab"));
+
+    await waitFor(() => {
+      const state = store.getState().sqlStudioWorkspace;
+      expect(state.tabs).toHaveLength(2);
+      expect(state.activeTabId).toBe(state.tabs[1]?.id ?? null);
+      expect(state.tabs[1]?.sql).toBe("");
+    });
+
+    expect((getSqlEditor() as HTMLTextAreaElement).value).toBe("");
   });
 
   it("starts with the inspector collapsed and renders table metadata when expanded", async () => {
@@ -401,7 +429,7 @@ describe("SqlStudio page", () => {
       refetch: mockRefetchSchemaTree,
     });
 
-    renderSqlStudio();
+    await renderSqlStudio();
 
     expect(screen.queryByText("Table Information")).toBeNull();
     expect(screen.queryByText("Commit")).toBeNull();
@@ -423,7 +451,7 @@ describe("SqlStudio page", () => {
   });
 
   it("refreshes the Explorer when the refresh button is clicked", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.click(screen.getByRole("button", { name: /refresh explorer/i }));
 
@@ -433,7 +461,7 @@ describe("SqlStudio page", () => {
   });
 
   it("refetches the Explorer schema after a successful create table query", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "CREATE TABLE default.audit_log (id INT PRIMARY KEY)" },
@@ -461,7 +489,7 @@ describe("SqlStudio page", () => {
       logs: [],
     });
 
-    renderSqlStudio();
+    await renderSqlStudio();
 
     const fullSql = "SELECT id FROM default.events; SELECT name FROM default.events";
     const selectedSql = "SELECT id FROM default.events";
@@ -497,7 +525,7 @@ describe("SqlStudio page", () => {
       logs: [],
     });
 
-    renderSqlStudio();
+    await renderSqlStudio();
 
     const fullSql = "SELECT id FROM default.events; SELECT name FROM default.events";
     const selectedSql = "SELECT name FROM default.events";
@@ -522,8 +550,38 @@ describe("SqlStudio page", () => {
     });
   });
 
+  it("opens a SQL Studio tab with Ctrl/Cmd+T", async () => {
+    const { store } = await renderSqlStudio();
+
+    fireEvent.keyDown(window, { key: "t", ctrlKey: true });
+
+    await waitFor(() => {
+      const state = store.getState().sqlStudioWorkspace;
+      expect(state.tabs).toHaveLength(2);
+      expect(state.activeTabId).toBe(state.tabs[1]?.id ?? null);
+      expect(state.tabs[1]?.sql).toBe("");
+    });
+  });
+
+  it("saves the active query with Ctrl/Cmd+S", async () => {
+    const { store } = await renderSqlStudio();
+
+    fireEvent.change(getSqlEditor(), {
+      target: { value: "SELECT id, name FROM default.events" },
+    });
+
+    fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+
+    await waitFor(() => {
+      const state = store.getState().sqlStudioWorkspace;
+      expect(state.savedQueries).toHaveLength(1);
+      expect(state.savedQueries[0]?.sql).toBe("SELECT id, name FROM default.events");
+      expect(state.tabs[0]?.savedQueryId).toBeTruthy();
+    });
+  });
+
   it("starts a live subscription from the SQL Studio page and renders incoming change rows", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name FROM default.events" },
@@ -561,7 +619,7 @@ describe("SqlStudio page", () => {
   });
 
   it("removes the browser-added limit when live mode is enabled", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT * FROM default.events LIMIT 100;" },
@@ -582,8 +640,8 @@ describe("SqlStudio page", () => {
     });
   });
 
-  it("keeps manual limit queries unchanged when live mode is enabled", () => {
-    renderSqlStudio();
+  it("keeps manual limit queries unchanged when live mode is enabled", async () => {
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id FROM default.events LIMIT 100;" },
@@ -595,7 +653,7 @@ describe("SqlStudio page", () => {
   });
 
   it("passes the live subscription from option as an exact string checkpoint", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name FROM default.events" },
@@ -625,7 +683,7 @@ describe("SqlStudio page", () => {
       resolveSubscribe = resolve as (value: () => Promise<void>) => void;
     }));
 
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT * FROM dba.favorites LIMIT 100" },
@@ -650,7 +708,7 @@ describe("SqlStudio page", () => {
   });
 
   it("orders live subscription rows by _seq descending, including the initial batch", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name, _seq FROM default.events" },
@@ -691,7 +749,7 @@ describe("SqlStudio page", () => {
   });
 
   it("appends raw websocket send and receive traces to the log", async () => {
-    const { store } = renderSqlStudio();
+    const { store } = await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name FROM default.events" },
@@ -722,7 +780,7 @@ describe("SqlStudio page", () => {
   });
 
   it("marks the live query as errored when the websocket disconnects", async () => {
-    const { store } = renderSqlStudio();
+    const { store } = await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name FROM default.events" },
@@ -758,7 +816,7 @@ describe("SqlStudio page", () => {
   });
 
   it("shows a change badge on background subscription tabs and clears it when the tab is opened", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name FROM default.events" },
@@ -802,7 +860,11 @@ describe("SqlStudio page", () => {
   });
 
   it("hydrates and updates the synced workspace from dba.favorites", async () => {
-    renderSqlStudio();
+    const { store } = await renderSqlStudio();
+
+    await waitFor(() => {
+      expect(mockSubscribeToSyncedSqlStudioWorkspaceState).toHaveBeenCalled();
+    });
 
     await act(async () => {
       syncedWorkspaceCallback?.({
@@ -839,8 +901,12 @@ describe("SqlStudio page", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByRole("button", { name: /synced query/i })).toBeTruthy();
-    expect(screen.getByText("Favorite Query")).toBeTruthy();
+    await waitFor(() => {
+      const state = store.getState().sqlStudioWorkspace;
+      expect(state.tabs[0]?.title).toBe("Synced Query");
+      expect(state.tabs[0]?.sql).toBe("SELECT * FROM default.events");
+      expect(state.savedQueries[0]?.title).toBe("Favorite Query");
+    });
     
     // Verify it is inside the favorites section
     const favoriteButton = screen.getByText("Favorite Query").closest("button");
@@ -881,11 +947,76 @@ describe("SqlStudio page", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByRole("button", { name: /synced query updated/i })).toBeTruthy();
+    await waitFor(() => {
+      const state = store.getState().sqlStudioWorkspace;
+      expect(state.tabs[0]?.title).toBe("Synced Query Updated");
+      expect(state.tabs[0]?.sql).toBe("SELECT id FROM default.events");
+      expect(state.savedQueries[0]?.sql).toBe("SELECT id FROM default.events");
+    });
+  });
+
+  it("loads favorites from the database before bootstrapping a blank workspace", async () => {
+    vi.useFakeTimers();
+
+    const workspace = {
+      version: 1,
+      tabs: [
+        {
+          id: "synced-tab",
+          name: "Favorite Query",
+          query: "SELECT * FROM default.events",
+          settings: {
+            isDirty: false,
+            isLive: false,
+            liveStatus: "idle",
+            resultView: "results",
+            lastSavedAt: null,
+            savedQueryId: "saved-1",
+          },
+        },
+      ],
+      savedQueries: [
+        {
+          id: "saved-1",
+          title: "Favorite Query",
+          sql: "SELECT * FROM default.events",
+          lastSavedAt: "2026-03-27T00:00:00.000Z",
+          isLive: false,
+          openedRecently: true,
+          isCurrentTab: true,
+        },
+      ],
+      activeTabId: "synced-tab",
+      updatedAt: "2026-03-27T00:00:00.000Z",
+    };
+
+    mockLoadSyncedSqlStudioWorkspaceState.mockResolvedValue(workspace);
+
+    await renderSqlStudio();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getAllByRole("button", { name: /favorite query/i }).length).toBeGreaterThan(0);
+
+    expect(screen.queryByRole("button", { name: /untitled query/i })).toBeNull();
+    expect(mockLoadSyncedSqlStudioWorkspaceState).toHaveBeenCalledWith("root");
+    expect(mockLoadSyncedSqlStudioWorkspaceState.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSubscribeToSyncedSqlStudioWorkspaceState.mock.invocationCallOrder[0],
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    expect(mockSaveSyncedSqlStudioWorkspaceState).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it("persists favorites through the synced workspace payload", async () => {
-    renderSqlStudio();
+    await renderSqlStudio();
 
     await act(async () => {
       syncedWorkspaceCallback?.(null);
@@ -918,7 +1049,7 @@ describe("SqlStudio page", () => {
 
   it("keeps the current workspace when the page remounts", async () => {
     const store = createTestStore();
-    const firstRender = renderSqlStudio(store);
+    const firstRender = await renderSqlStudio(store);
 
     await act(async () => {
       syncedWorkspaceCallback?.(null);
@@ -935,7 +1066,7 @@ describe("SqlStudio page", () => {
     });
 
     firstRender.unmount();
-    renderSqlStudio(store);
+    await renderSqlStudio(store);
 
     expect(screen.getAllByText("Untitled query").length).toBeGreaterThan(0);
     expect(screen.getByDisplayValue("SELECT id, name FROM default.events")).toBeTruthy();
@@ -944,7 +1075,7 @@ describe("SqlStudio page", () => {
   it("debounces synced workspace writes", async () => {
     vi.useFakeTimers();
 
-    renderSqlStudio();
+    await renderSqlStudio();
 
     await act(async () => {
       syncedWorkspaceCallback?.(null);

--- a/ui/src/pages/SqlStudio.tsx
+++ b/ui/src/pages/SqlStudio.tsx
@@ -90,6 +90,7 @@ import {
 import { ExplorerTableContextMenu } from "@/features/sql-studio/components/ExplorerTableContextMenu";
 import {
   buildSyncedSqlStudioWorkspaceState,
+  loadSyncedSqlStudioWorkspaceState,
   saveSyncedSqlStudioWorkspaceState,
   subscribeToSyncedSqlStudioWorkspaceState,
   type SqlStudioSyncedWorkspaceState,
@@ -226,6 +227,7 @@ export default function SqlStudio() {
   const liveSubscriptionIdRef = useRef<Record<string, string>>({});
   const consumedPrefillKeyRef = useRef<string | null>(null);
   const activeTabIdRef = useRef<string | null>(null);
+  const tabsRef = useRef<QueryTab[]>(tabs);
   const lastSyncedWorkspaceSnapshotRef = useRef<string | null>(null);
 
   const activeTab = useMemo(
@@ -248,56 +250,69 @@ export default function SqlStudio() {
   }, [schema, selectedTableKey]);
 
   useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  useEffect(() => {
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
 
   const applySyncedWorkspace = useCallback((workspace: SqlStudioSyncedWorkspaceState) => {
-    startTransition(() => {
-      dispatch(hydrateSqlStudioWorkspace({
-        tabs: workspace.tabs.map(mapPersistedTabToQueryTab),
-        savedQueries: workspace.savedQueries.map(mapPersistedSavedQuery),
-        activeTabId: workspace.activeTabId,
-      }));
-    });
+    dispatch(hydrateSqlStudioWorkspace({
+      tabs: workspace.tabs.map(mapPersistedTabToQueryTab),
+      savedQueries: workspace.savedQueries.map(mapPersistedSavedQuery),
+      activeTabId: workspace.activeTabId,
+    }));
   }, [dispatch]);
 
-  // Initialize with a single blank tab while waiting for remote workspace to load.
   useEffect(() => {
-    if (tabs.length > 0) {
-      setIsUiHydrated(true);
+    const username = user?.username?.trim();
+    if (!username) {
+      setIsUiHydrated(false);
+      setIsRemoteWorkspaceHydrated(false);
+      lastSyncedWorkspaceSnapshotRef.current = null;
       return;
     }
 
-    const blankTab = createQueryTab(1);
-    dispatch(hydrateSqlStudioWorkspace({
-      tabs: [blankTab],
-      savedQueries: [],
-      activeTabId: blankTab.id,
-    }));
-    setIsUiHydrated(true);
-  }, [dispatch, tabs.length]);
-
-  useEffect(() => {
-    if (!isUiHydrated || !user?.username) {
-      return;
-    }
-
-    const username = user.username;
+    setIsUiHydrated(false);
+    setIsRemoteWorkspaceHydrated(false);
+    lastSyncedWorkspaceSnapshotRef.current = null;
 
     let cancelled = false;
     let remoteUnsubscribe: Unsubscribe | null = null;
-    let didReceiveInitialSnapshot = false;
+
+    const hydrateBlankWorkspace = () => {
+      if (tabsRef.current.length > 0) {
+        return;
+      }
+
+      const blankTab = createQueryTab(1);
+      dispatch(hydrateSqlStudioWorkspace({
+        tabs: [blankTab],
+        savedQueries: [],
+        activeTabId: blankTab.id,
+      }));
+    };
 
     void (async () => {
       try {
+        const initialWorkspace = await loadSyncedSqlStudioWorkspaceState(username);
+        if (cancelled) {
+          return;
+        }
+
+        if (initialWorkspace) {
+          lastSyncedWorkspaceSnapshotRef.current = serializeSyncedWorkspaceSnapshot(initialWorkspace);
+          applySyncedWorkspace(initialWorkspace);
+        } else {
+          hydrateBlankWorkspace();
+        }
+
+        setIsUiHydrated(true);
+
         remoteUnsubscribe = await subscribeToSyncedSqlStudioWorkspaceState(username, (nextWorkspace) => {
           if (cancelled) {
             return;
-          }
-
-          if (!didReceiveInitialSnapshot) {
-            didReceiveInitialSnapshot = true;
-            setIsRemoteWorkspaceHydrated(true);
           }
 
           if (!nextWorkspace) {
@@ -313,6 +328,10 @@ export default function SqlStudio() {
           applySyncedWorkspace(nextWorkspace);
         });
 
+        if (!cancelled) {
+          setIsRemoteWorkspaceHydrated(true);
+        }
+
         if (cancelled && remoteUnsubscribe) {
           void remoteUnsubscribe();
           remoteUnsubscribe = null;
@@ -320,6 +339,8 @@ export default function SqlStudio() {
       } catch (error) {
         if (!cancelled) {
           console.error("Failed to initialize synced SQL Studio workspace subscription", error);
+          hydrateBlankWorkspace();
+          setIsUiHydrated(true);
           setIsRemoteWorkspaceHydrated(true);
         }
       }
@@ -331,7 +352,7 @@ export default function SqlStudio() {
         void remoteUnsubscribe();
       }
     };
-  }, [applySyncedWorkspace, isUiHydrated, user?.username]);
+  }, [applySyncedWorkspace, dispatch, user?.username]);
 
   useEffect(() => {
     if (!selectedTableKey && schema.length > 0 && schema[0].tables.length > 0) {
@@ -411,12 +432,12 @@ export default function SqlStudio() {
     await refetchSchemaTree();
   }, [refetchSchemaTree]);
 
-  const addTab = () => {
+  const addTab = useCallback(() => {
     const nextIndex = tabs.length + 1;
     const tab = createQueryTab(nextIndex);
     dispatch(addWorkspaceTab(tab));
     dispatch(setWorkspaceActiveTabId(tab.id));
-  };
+  }, [dispatch, tabs.length]);
 
   const cleanupLiveSubscription = useCallback((tabId: string) => {
     const unsubscribe = liveUnsubscribeRef.current[tabId];
@@ -837,6 +858,49 @@ export default function SqlStudio() {
       isDirty: false,
     });
   }, [dispatch, savedQueries, tabs, tabResults, updateTab]);
+
+  const saveActiveTab = useCallback(() => {
+    if (!activeTab) {
+      return;
+    }
+
+    saveTab(activeTab.id, false);
+  }, [activeTab, saveTab]);
+
+  useEffect(() => {
+    const handleGlobalShortcut = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) {
+        return;
+      }
+
+      if (!(event.ctrlKey || event.metaKey) || event.altKey || event.shiftKey) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (key === "t") {
+        event.preventDefault();
+        event.stopPropagation();
+        addTab();
+        return;
+      }
+
+      if (key === "s") {
+        if (!activeTab) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        saveActiveTab();
+      }
+    };
+
+    window.addEventListener("keydown", handleGlobalShortcut, true);
+    return () => {
+      window.removeEventListener("keydown", handleGlobalShortcut, true);
+    };
+  }, [activeTab, addTab, saveActiveTab]);
 
   const renameActiveTab = useCallback((title: string) => {
     if (!activeTab) {

--- a/ui/src/services/sqlStudioWorkspaceSyncService.test.ts
+++ b/ui/src/services/sqlStudioWorkspaceSyncService.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecuteSql = vi.fn();
+const mockSubscribeRows = vi.fn();
+
+vi.mock("@/lib/kalam-client", () => ({
+  executeSql: (...args: unknown[]) => mockExecuteSql(...args),
+  subscribeRows: (...args: unknown[]) => mockSubscribeRows(...args),
+}));
+
+describe("sqlStudioWorkspaceSyncService", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockExecuteSql.mockReset();
+    mockSubscribeRows.mockReset();
+  });
+
+  it("hydrates legacy favorites before opening the live subscription", async () => {
+    const workspace = {
+      version: 1,
+      tabs: [
+        {
+          id: "tab-1",
+          name: "Favorite Query",
+          query: "SELECT * FROM default.events",
+          settings: {
+            isDirty: false,
+            isLive: false,
+            liveStatus: "idle",
+            resultView: "results",
+            lastSavedAt: null,
+            savedQueryId: "saved-1",
+          },
+        },
+      ],
+      savedQueries: [
+        {
+          id: "saved-1",
+          title: "Favorite Query",
+          sql: "SELECT * FROM default.events",
+          lastSavedAt: "2026-04-23T00:00:00.000Z",
+          isLive: false,
+          openedRecently: true,
+          isCurrentTab: true,
+        },
+      ],
+      activeTabId: "tab-1",
+      updatedAt: "2026-04-23T00:00:00.000Z",
+    };
+
+    mockExecuteSql
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "sql-studio-workspace", payload: workspace }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockSubscribeRows.mockResolvedValue(async () => {});
+
+    const { subscribeToSyncedSqlStudioWorkspaceState } = await import("@/services/sqlStudioWorkspaceSyncService");
+    const onChange = vi.fn();
+
+    await subscribeToSyncedSqlStudioWorkspaceState("admin", onChange);
+
+    expect(onChange).toHaveBeenCalledWith(workspace);
+    expect(mockSubscribeRows).toHaveBeenCalledWith(
+      "SELECT id, payload FROM dba.favorites WHERE id = 'sql-studio-state:admin:workspace'",
+      expect.any(Function),
+    );
+    expect(mockExecuteSql).toHaveBeenCalledWith(
+      "INSERT INTO dba.favorites (id, payload) VALUES ('sql-studio-state:admin:workspace', '{\"version\":1,\"tabs\":[{\"id\":\"tab-1\",\"name\":\"Favorite Query\",\"query\":\"SELECT * FROM default.events\",\"settings\":{\"isDirty\":false,\"isLive\":false,\"liveStatus\":\"idle\",\"resultView\":\"results\",\"lastSavedAt\":null,\"savedQueryId\":\"saved-1\"}}],\"savedQueries\":[{\"id\":\"saved-1\",\"title\":\"Favorite Query\",\"sql\":\"SELECT * FROM default.events\",\"lastSavedAt\":\"2026-04-23T00:00:00.000Z\",\"isLive\":false,\"openedRecently\":true,\"isCurrentTab\":true}],\"activeTabId\":\"tab-1\",\"updatedAt\":\"2026-04-23T00:00:00.000Z\"}')",
+    );
+  });
+});

--- a/ui/src/services/sqlStudioWorkspaceSyncService.ts
+++ b/ui/src/services/sqlStudioWorkspaceSyncService.ts
@@ -316,6 +316,9 @@ export async function subscribeToSyncedSqlStudioWorkspaceState(
   username: string,
   onChange: (state: SqlStudioSyncedWorkspaceState | null) => void,
 ): Promise<Unsubscribe> {
+  const initialWorkspace = await loadSyncedSqlStudioWorkspaceState(username);
+  onChange(initialWorkspace);
+
   const rowId = buildWorkspaceRowId(username);
   return subscribeRows<Record<string, unknown>>(
     buildWorkspaceSubscriptionSql(rowId),


### PR DESCRIPTION
Derive topic message keys from table primary keys and improve client reconnection handling. Add TopicPrimaryKeyLookup trait and SchemaRegistryTopicPrimaryKeyLookup, wire an optional primary-key lookup into TopicPublisherService, and use PK columns to extract stable message keys and determine partitioning. Refactor payload handling to cache a JSON map, add extract_primary_key and hash_key helpers, and adjust publishing logic and tests to ensure same-PK rows land in the same partition. On the client side, expose an explicit connect() in the TS SDK, add browser/WASM reconnection scheduling and resume logic (resubscribe on reconnect), update WASM client ping defaults, and add runtime/coverage tests plus a browser resume e2e page. Misc: update related imports/exports and bump Tailwind-related entries in UI package-lock.json.

## Summary

Describe the change in 1-3 sentences.

## Related

- Closes #
- Related docs/specs:

## What Changed

- [ X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] Breaking change

## Validation

List the commands or checks you ran.

```bash
# Example
```

## Checklist

- [ ] I kept the change scoped to the problem being solved.
- [ ] I added or updated tests when behavior changed.
- [ ] I updated docs when the public behavior, workflow, or architecture changed.
- [ ] If this touches auth, SQL, APIs, storage, or transport, I reviewed the security guidance in `SECURITY.md` and `docs/security/security-checklist.md`.

## Notes

Add rollout notes, screenshots, or follow-up work if needed.