### PR TITLE
Fix ORM CI: build @kalamdb/client from source

### DIFF
--- a/.github/workflows/orm.yml
+++ b/.github/workflows/orm.yml
@@ -25,13 +25,36 @@ jobs:
           KALAMDB_JWT_SECRET: "ci-test-secret-at-least-32-chars-long"
           KALAMDB_ALLOW_REMOTE_SETUP: "true"
 
+    env:
+      RUST_VERSION: "1.92.0"
+      WASM_PACK_VERSION: "0.14.0"
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: orm-client-build
+          cache-on-failure: true
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+
+      - name: Build @kalamdb/client from source
+        working-directory: link/sdks/typescript/client
+        run: npm install && npm run build
 
       - name: Wait for KalamDB
         run: |
@@ -60,7 +83,7 @@ jobs:
 
       - name: Run unit tests
         working-directory: link/sdks/typescript/orm
-        run: node --test tests/file-column.test.mjs tests/strip-defaults.test.mjs
+        run: node --test tests/file-column.test.mjs tests/strip-defaults.test.mjs tests/temporal-normalize.test.mjs
 
       - name: Run integration tests
         working-directory: link/sdks/typescript/orm

--- a/link/sdks/typescript/orm/src/driver.ts
+++ b/link/sdks/typescript/orm/src/driver.ts
@@ -1,14 +1,14 @@
 import type { RemoteCallback } from 'drizzle-orm/pg-proxy';
 import type { KalamDBClient } from '@kalamdb/client';
 
-function toMilliseconds(value: number): number {
+export function toMilliseconds(value: number): number {
   if (value > 1e15) return Math.floor(value / 1000);
   if (value > 1e12) return value;
   if (value > 1e9) return value * 1000;
   return value;
 }
 
-function normalizeTemporalValue(value: unknown): unknown {
+export function normalizeTemporalValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
 
   if (value instanceof Date) {

--- a/link/sdks/typescript/orm/tests/driver.test.mjs
+++ b/link/sdks/typescript/orm/tests/driver.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { drizzle } from 'drizzle-orm/pg-proxy';
-import { pgTable, text, bigint } from 'drizzle-orm/pg-core';
+import { pgTable, text, bigint, timestamp } from 'drizzle-orm/pg-core';
 import { eq, desc } from 'drizzle-orm';
 import { kalamDriver, file } from '../dist/index.js';
 import { requirePassword, createTestClient } from './helpers.mjs';
@@ -13,17 +13,16 @@ let db;
 
 const system_users = pgTable('system.users', {
   user_id: text('user_id'),
-  username: text('username'),
   role: text('role'),
   email: text('email'),
 });
 
 const system_audit_log = pgTable('system.audit_log', {
   audit_id: text('audit_id'),
-  actor_username: text('actor_username'),
+  actor_user_id: text('actor_user_id'),
   action: text('action'),
   target: text('target'),
-  timestamp: bigint('timestamp', { mode: 'number' }),
+  timestamp: timestamp('timestamp', { mode: 'string' }),
 });
 
 before(async () => {
@@ -46,7 +45,7 @@ describe('kalamDriver', () => {
   it('returns typed fields', async () => {
     const rows = await db.select().from(system_users);
     const first = rows[0];
-    assert.ok(typeof first.username === 'string');
+    assert.ok(typeof first.user_id === 'string');
     assert.ok(typeof first.role === 'string');
   });
 
@@ -75,10 +74,10 @@ describe('kalamDriver', () => {
 
   it('supports SELECT with specific columns', async () => {
     const rows = await db
-      .select({ username: system_users.username, role: system_users.role })
+      .select({ user_id: system_users.user_id, role: system_users.role })
       .from(system_users);
     assert.ok(rows.length > 0);
-    assert.ok('username' in rows[0]);
+    assert.ok('user_id' in rows[0]);
     assert.ok('role' in rows[0]);
     assert.ok(!('email' in rows[0]));
   });
@@ -130,7 +129,7 @@ describe('kalamDriver', () => {
     const table = pgTable('test_orm_insert.multi_defaults', {
       id: bigint('id', { mode: 'number' }),
       label: text('label'),
-      created_at: bigint('created_at', { mode: 'number' }),
+      created_at: timestamp('created_at', { mode: 'string' }),
     });
 
     await db.insert(table).values({ label: 'multi-default-test' });
@@ -138,7 +137,8 @@ describe('kalamDriver', () => {
     assert.equal(rows.length, 1);
     assert.equal(rows[0].label, 'multi-default-test');
     assert.ok(rows[0].id > 0, 'id should be auto-generated');
-    assert.ok(rows[0].created_at > 0, 'created_at should be auto-generated');
+    assert.ok(typeof rows[0].created_at === 'string', 'created_at should be a string');
+    assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(rows[0].created_at), 'created_at should be ISO 8601 format');
 
     await client.query('DROP TABLE IF EXISTS test_orm_insert.multi_defaults');
     await client.query('DROP NAMESPACE IF EXISTS test_orm_insert');

--- a/link/sdks/typescript/orm/tests/generate.test.mjs
+++ b/link/sdks/typescript/orm/tests/generate.test.mjs
@@ -56,9 +56,9 @@ describe('generateSchema', () => {
 
   it('uses snake_case for field names', () => {
     assert.ok(fullSchema.includes("user_id:"));
-    assert.ok(fullSchema.includes("actor_username:"));
+    assert.ok(fullSchema.includes("actor_user_id:"));
     assert.ok(!fullSchema.includes("userId:"));
-    assert.ok(!fullSchema.includes("actorUsername:"));
+    assert.ok(!fullSchema.includes("actorUserId:"));
   });
 
   it('maps timestamps to timestamp with mode string', () => {
@@ -149,5 +149,12 @@ describe('generateSchema', () => {
     assert.ok(schema.includes("system_audit_log"));
     assert.ok(schema.includes("dba_"));
     assert.ok(schema.includes("test_gen_uploads"));
+  });
+
+  it('deduplicates tables (no duplicate exports)', () => {
+    const exportLines = fullSchema.split('\n').filter((l) => l.startsWith('export const '));
+    const tableNames = exportLines.map((l) => l.match(/export const (\w+)/)?.[1]);
+    const uniqueNames = new Set(tableNames);
+    assert.equal(tableNames.length, uniqueNames.size, 'each table should appear exactly once');
   });
 });

--- a/link/sdks/typescript/orm/tests/temporal-normalize.test.mjs
+++ b/link/sdks/typescript/orm/tests/temporal-normalize.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { toMilliseconds, normalizeTemporalValue } from '../dist/driver.js';
+
+describe('toMilliseconds', () => {
+  it('passes through millisecond values unchanged', () => {
+    assert.equal(toMilliseconds(1777018016782), 1777018016782);
+  });
+
+  it('converts microseconds to milliseconds', () => {
+    assert.equal(toMilliseconds(1777018016782000), 1777018016782);
+  });
+
+  it('converts seconds to milliseconds', () => {
+    assert.equal(toMilliseconds(1777018016), 1777018016000);
+  });
+
+  it('passes through small numbers as-is', () => {
+    assert.equal(toMilliseconds(0), 0);
+    assert.equal(toMilliseconds(1000), 1000);
+  });
+});
+
+describe('normalizeTemporalValue', () => {
+  it('returns null/undefined unchanged', () => {
+    assert.equal(normalizeTemporalValue(null), null);
+    assert.equal(normalizeTemporalValue(undefined), undefined);
+  });
+
+  it('converts Date object to ISO string', () => {
+    const date = new Date('2026-04-25T10:00:00.000Z');
+    assert.equal(normalizeTemporalValue(date), '2026-04-25T10:00:00.000Z');
+  });
+
+  it('converts millisecond number to ISO string', () => {
+    const result = normalizeTemporalValue(1777018016782);
+    assert.equal(result, '2026-04-24T08:06:56.782Z');
+  });
+
+  it('converts microsecond number to ISO string', () => {
+    const result = normalizeTemporalValue(1777018016782000);
+    assert.equal(result, '2026-04-24T08:06:56.782Z');
+  });
+
+  it('converts second number to ISO string', () => {
+    const result = normalizeTemporalValue(1777018016);
+    assert.equal(result, '2026-04-24T08:06:56.000Z');
+  });
+
+  it('converts numeric string to ISO string', () => {
+    const result = normalizeTemporalValue('1777018016782');
+    assert.equal(result, '2026-04-24T08:06:56.782Z');
+  });
+
+  it('passes through non-numeric strings unchanged', () => {
+    assert.equal(normalizeTemporalValue('hello'), 'hello');
+    assert.equal(normalizeTemporalValue('2026-04-24T08:06:56.782Z'), '2026-04-24T08:06:56.782Z');
+  });
+
+  it('passes through other types unchanged', () => {
+    assert.equal(normalizeTemporalValue(true), true);
+    assert.deepEqual(normalizeTemporalValue({ foo: 'bar' }), { foo: 'bar' });
+    assert.deepEqual(normalizeTemporalValue([1, 2]), [1, 2]);
+  });
+
+  it('handles trimmed numeric strings', () => {
+    const result = normalizeTemporalValue('  1777018016782  ');
+    assert.equal(result, '2026-04-24T08:06:56.782Z');
+  });
+});


### PR DESCRIPTION
ORM CI was failing because it tries to build @kalamdb/client (file:../client)
which needs Rust + wasm-pack to compile WASM.

Install Rust + wasm-pack first, then build the client SDK from source like
sdks.yml does. This way the ORM tests against the actual current client
source, not a possibly-stale published version.