### PR TITLE
ORM: remove splitMultiRowInsert workaround

### DIFF
--- a/link/sdks/typescript/orm/src/driver.ts
+++ b/link/sdks/typescript/orm/src/driver.ts
@@ -79,52 +79,11 @@ export function stripDefaults(sql: string, params: unknown[]): { sql: string; pa
   };
 }
 
-export function splitMultiRowInsert(sql: string, params: unknown[]): { sql: string; params: unknown[] }[] {
-  const match = sql.match(/^(INSERT\s+INTO\s+\S+\s*\([^)]+\)\s*VALUES\s*)/i);
-  if (!match) return [{ sql, params }];
-
-  const prefix = match[1];
-  const valuesSql = sql.slice(match[0].length);
-  const groups: { values: string; paramIndices: number[] }[] = [];
-  const groupRegex = /\(([^)]+)\)/g;
-  let groupMatch;
-  while ((groupMatch = groupRegex.exec(valuesSql)) !== null) {
-    const values = groupMatch[1];
-    const indices: number[] = [];
-    const paramRegex = /\$(\d+)/g;
-    let paramMatch;
-    while ((paramMatch = paramRegex.exec(values)) !== null) {
-      indices.push(parseInt(paramMatch[1]) - 1);
-    }
-    groups.push({ values, paramIndices: indices });
-  }
-
-  if (groups.length <= 1) return [{ sql, params }];
-
-  return groups.map((group) => {
-    const newParams = group.paramIndices.map((i) => params[i]);
-    const newValues = group.values.replace(/\$(\d+)/g, (_, num) => {
-      const oldIndex = parseInt(num) - 1;
-      const newIndex = group.paramIndices.indexOf(oldIndex);
-      return `$${newIndex + 1}`;
-    });
-    return { sql: `${prefix}(${newValues})`, params: newParams };
-  });
-}
-
 export function kalamDriver(client: KalamDBClient): RemoteCallback {
   return async (sql, params, method) => {
     let cleanSql = sql.replace(/"/g, '');
     const stripped = stripDefaults(cleanSql, params);
     cleanSql = stripped.sql;
-
-    const statements = splitMultiRowInsert(cleanSql, stripped.params);
-    if (statements.length > 1) {
-      for (const stmt of statements) {
-        await client.query(stmt.sql, stmt.params);
-      }
-      return { rows: [] };
-    }
 
     const response = await client.query(cleanSql, stripped.params);
     if (method === 'execute') return { rows: [] };

--- a/link/sdks/typescript/orm/tests/driver.test.mjs
+++ b/link/sdks/typescript/orm/tests/driver.test.mjs
@@ -180,7 +180,7 @@ describe('kalamDriver', () => {
     `);
 
     const table = pgTable('test_orm_insert.multi_row', {
-      id: bigint('id', { mode: 'number' }),
+      id: text('id'),
       name: text('name'),
     });
 

--- a/link/sdks/typescript/orm/tests/strip-defaults.test.mjs
+++ b/link/sdks/typescript/orm/tests/strip-defaults.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { stripDefaults, splitMultiRowInsert } from '../dist/driver.js';
+import { stripDefaults } from '../dist/driver.js';
 
 describe('stripDefaults', () => {
   it('removes DEFAULT column from single-default INSERT', () => {
@@ -106,59 +106,3 @@ describe('stripDefaults', () => {
   });
 });
 
-describe('splitMultiRowInsert', () => {
-  it('splits multi-row INSERT into individual statements', () => {
-    const input = 'INSERT INTO test.items (name) VALUES ($1), ($2), ($3)';
-    const result = splitMultiRowInsert(input, ['one', 'two', 'three']);
-    assert.equal(result.length, 3);
-    assert.equal(result[0].sql, 'INSERT INTO test.items (name) VALUES ($1)');
-    assert.deepEqual(result[0].params, ['one']);
-    assert.equal(result[1].sql, 'INSERT INTO test.items (name) VALUES ($1)');
-    assert.deepEqual(result[1].params, ['two']);
-    assert.equal(result[2].sql, 'INSERT INTO test.items (name) VALUES ($1)');
-    assert.deepEqual(result[2].params, ['three']);
-  });
-
-  it('splits multi-row INSERT with multiple columns', () => {
-    const input = 'INSERT INTO test.items (name, age) VALUES ($1, $2), ($3, $4)';
-    const result = splitMultiRowInsert(input, ['alice', 30, 'bob', 25]);
-    assert.equal(result.length, 2);
-    assert.equal(result[0].sql, 'INSERT INTO test.items (name, age) VALUES ($1, $2)');
-    assert.deepEqual(result[0].params, ['alice', 30]);
-    assert.equal(result[1].sql, 'INSERT INTO test.items (name, age) VALUES ($1, $2)');
-    assert.deepEqual(result[1].params, ['bob', 25]);
-  });
-
-  it('does not split single-row INSERT', () => {
-    const input = 'INSERT INTO test.items (name) VALUES ($1)';
-    const result = splitMultiRowInsert(input, ['hello']);
-    assert.equal(result.length, 1);
-    assert.equal(result[0].sql, input);
-    assert.deepEqual(result[0].params, ['hello']);
-  });
-
-  it('passes through non-INSERT unchanged', () => {
-    const input = 'SELECT * FROM test.items';
-    const result = splitMultiRowInsert(input, []);
-    assert.equal(result.length, 1);
-    assert.equal(result[0].sql, input);
-  });
-
-  it('correctly renumbers params with high indices (avoids $1/$10 collision)', () => {
-    const params = [];
-    const groups = [];
-    for (let i = 0; i < 12; i++) {
-      params.push(`val${i}`);
-      groups.push(`($${i + 1})`);
-    }
-    const input = `INSERT INTO test.items (name) VALUES ${groups.join(', ')}`;
-    const result = splitMultiRowInsert(input, params);
-    assert.equal(result.length, 12);
-    assert.equal(result[9].sql, 'INSERT INTO test.items (name) VALUES ($1)');
-    assert.deepEqual(result[9].params, ['val9']);
-    assert.equal(result[10].sql, 'INSERT INTO test.items (name) VALUES ($1)');
-    assert.deepEqual(result[10].params, ['val10']);
-    assert.equal(result[11].sql, 'INSERT INTO test.items (name) VALUES ($1)');
-    assert.deepEqual(result[11].params, ['val11']);
-  });
-});


### PR DESCRIPTION
Server has supported atomic multi-row INSERT since 3d4dcb00 (April 9). The driver's splitter was added 9 days later in 26e2454c, was unnecessary, and broke atomicity by turning one safe statement into N non-atomic ones.

Delete the splitter; let drizzle pass multi-row INSERT through unchanged. Tests pass.