### PR TITLE
Improve Docker build: multi-arch and slim images

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -95,7 +95,7 @@ This is the path used by the release workflow. Build the Rust binaries once, the
 
 That script will:
 
-1. Build `kalamdb-server` and `kalam` in release mode
+1. Build Linux-targeted `kalamdb-server` and `kalam` binaries for your local Docker platform
 2. Stage them as a Docker build context
 3. Build `docker/build/Dockerfile.prebuilt`
 4. Run smoke tests against the resulting image
@@ -104,12 +104,29 @@ That script will:
 
 ```bash
 cd /path/to/KalamDB
-mkdir -p binaries-amd64
-cp backend/target/release/kalamdb-server binaries-amd64/
-cp backend/target/release/kalam binaries-amd64/
+
+case "$(uname -m)" in
+  x86_64)
+    export LOCAL_TARGET=x86_64-unknown-linux-gnu
+    export LOCAL_PLATFORM=linux/amd64
+    export BIN_DIR=binaries-amd64
+    SKIP_UI_BUILD=1 cargo build --release --target "$LOCAL_TARGET" --features mimalloc -p kalamdb-server -p kalam-cli --bin kalamdb-server --bin kalam
+    ;;
+  arm64)
+    export LOCAL_TARGET=aarch64-unknown-linux-gnu
+    export LOCAL_PLATFORM=linux/arm64
+    export BIN_DIR=binaries-arm64
+    SKIP_UI_BUILD=1 cross build --release --target "$LOCAL_TARGET" --features mimalloc -p kalamdb-server -p kalam-cli --bin kalamdb-server --bin kalam
+    ;;
+esac
+
+mkdir -p "$BIN_DIR"
+cp "target/$LOCAL_TARGET/release/kalamdb-server" "$BIN_DIR/"
+cp "target/$LOCAL_TARGET/release/kalam" "$BIN_DIR/"
 
 docker build \
-  --build-context binaries=binaries-amd64 \
+  --platform "$LOCAL_PLATFORM" \
+  --build-context binaries="$BIN_DIR" \
   -f docker/build/Dockerfile.prebuilt \
   -t kalamdb:local \
   .

--- a/docker/build/Dockerfile.prebuilt
+++ b/docker/build/Dockerfile.prebuilt
@@ -1,27 +1,19 @@
-# Lightweight Docker image for KalamDB using pre-built binaries
-#
-# Option 1: Build with local binaries (after `cargo build --release`):
-#   docker build -f docker/build/Dockerfile.prebuilt -t jamals86/kalamdb:latest .
-#
-# Option 2: Used in release workflow with pre-compiled binaries:
-#   docker build --build-context binaries=binaries-amd64 -f docker/build/Dockerfile.prebuilt -t jamals86/kalamdb:latest .
-
-# Prepare runtime assets without pulling a full distro into the final image.
+# ---------- Stage 1: runtime prep ----------
 FROM busybox:1.36.1-musl AS runtime-prep
 
 RUN mkdir -p /runtime/usr/local/bin /runtime/data/rocksdb /runtime/data/storage /runtime/data/logs /runtime/config && \
     cp /bin/busybox /runtime/usr/local/bin/busybox
 
-# Copy default server configuration and normalize the data path before the final stage.
 COPY backend/server.example.toml /runtime/config/server.toml
 RUN sed -i 's|data_path = "\./data"|data_path = "/data"|g' /runtime/config/server.toml
 
-# Prepare release-built Linux binaries for the runtime image.
-# Strip debug/symbol data when possible to keep the final image smaller.
-FROM ubuntu:24.04 AS binary-prep
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends binutils && \
+# ---------- Stage 2: binary prep ----------
+FROM debian:bookworm-slim AS binary-prep
+
+RUN apt-get update -o Acquire::Retries=3 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        binutils ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /staged/usr/local/bin
@@ -29,72 +21,43 @@ RUN mkdir -p /staged/usr/local/bin
 COPY --from=binaries kalamdb-server /staged/usr/local/bin/kalamdb-server
 COPY --from=binaries kalam /staged/usr/local/bin/kalam-cli
 
-RUN chmod 755 /staged/usr/local/bin/kalamdb-server /staged/usr/local/bin/kalam-cli && \
-    strip --strip-unneeded /staged/usr/local/bin/kalamdb-server /staged/usr/local/bin/kalam-cli || true
+RUN chmod 755 /staged/usr/local/bin/* && \
+    strip --strip-unneeded /staged/usr/local/bin/* || true
 
-# Ubuntu 24.04 is the current LTS release. The base image already includes bash,
-# so only install CA certificates to keep the runtime as small as possible while
-# preserving HTTPS support for CLI and runtime tooling.
-FROM ubuntu:24.04
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates && \
+# ---------- Stage 3: final runtime ----------
+FROM debian:bookworm-slim
+
+RUN apt-get update -o Acquire::Retries=3 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates bash busybox-static && \
     rm -rf /var/lib/apt/lists/*
 
-ARG OCI_IMAGE_TITLE="KalamDB"
-ARG OCI_IMAGE_DESCRIPTION="SQL-first realtime state database for AI agents, chat products, and multi-tenant SaaS"
-ARG OCI_IMAGE_URL="https://kalamdb.org"
-ARG OCI_IMAGE_SOURCE="https://github.com/kalamstack/KalamDB"
-ARG OCI_IMAGE_DOCUMENTATION="https://kalamdb.org/docs"
-ARG OCI_IMAGE_VENDOR="KalamDB"
-ARG OCI_IMAGE_AUTHORS="Jamal Saad"
-ARG OCI_IMAGE_LICENSES="Apache-2.0"
-ARG OCI_IMAGE_VERSION="dev"
-ARG OCI_IMAGE_REVISION="unknown"
-ARG OCI_IMAGE_CREATED="unknown"
+# create user
+RUN groupadd -g 65532 kalamdb && \
+    useradd -u 65532 -g kalamdb -d /data -s /bin/bash kalamdb
 
-LABEL org.opencontainers.image.title="${OCI_IMAGE_TITLE}" \
-    org.opencontainers.image.description="${OCI_IMAGE_DESCRIPTION}" \
-    org.opencontainers.image.url="${OCI_IMAGE_URL}" \
-    org.opencontainers.image.source="${OCI_IMAGE_SOURCE}" \
-    org.opencontainers.image.documentation="${OCI_IMAGE_DOCUMENTATION}" \
-    org.opencontainers.image.vendor="${OCI_IMAGE_VENDOR}" \
-    org.opencontainers.image.authors="${OCI_IMAGE_AUTHORS}" \
-    org.opencontainers.image.licenses="${OCI_IMAGE_LICENSES}" \
-    org.opencontainers.image.version="${OCI_IMAGE_VERSION}" \
-    org.opencontainers.image.revision="${OCI_IMAGE_REVISION}" \
-    org.opencontainers.image.created="${OCI_IMAGE_CREATED}"
-
-# Copy pre-built binaries from the prepared binary stage.
-COPY --from=runtime-prep --chmod=755 /runtime/usr/local/bin/busybox /usr/local/bin/busybox
-COPY --from=binary-prep --chmod=755 /staged/usr/local/bin/kalamdb-server /usr/local/bin/kalamdb-server
-COPY --from=binary-prep --chmod=755 /staged/usr/local/bin/kalam-cli /usr/local/bin/kalam-cli
+# copy binaries
+COPY --from=binary-prep --chmod=755 /staged/usr/local/bin/kalamdb-server /usr/local/bin/
+COPY --from=binary-prep --chmod=755 /staged/usr/local/bin/kalam-cli /usr/local/bin/
 RUN ln -sf /usr/local/bin/kalam-cli /usr/local/bin/kalam
 
-# Copy writable runtime paths and the normalized config with non-root ownership.
+# copy runtime assets
 COPY --from=runtime-prep --chown=65532:65532 /runtime/data /data
 COPY --from=runtime-prep --chown=65532:65532 /runtime/config /config
 
-# Add a named runtime user/group entry and a writable HOME for the numeric UID.
-RUN printf 'kalamdb:x:65532:65532:KalamDB:/data:/bin/bash\n' >> /etc/passwd && \
-    printf 'kalamdb:x:65532:\n' >> /etc/group && \
-    mkdir -p /data/.kalam && \
+RUN mkdir -p /data/.kalam && \
     chown -R 65532:65532 /data /config
 
 ENV HOME=/data
-
-# Run as the same non-root uid/gid used by the previous distroless image.
 USER 65532:65532
-
-# Set working directory (server looks for server.toml here)
 WORKDIR /data
 
-# Expose default port
+VOLUME ["/data"]
+
 EXPOSE 8080
 
-# Health check: use wget GET to /dev/null (--spider sends HEAD which is incompatible with h2c auto-detect).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ["/usr/local/bin/busybox", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/health"]
+    CMD ["/bin/busybox", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/health"]
 
-# Default command: run server (looks for server.toml in current directory)
 CMD ["/usr/local/bin/kalamdb-server", "/config/server.toml"]

--- a/docker/build/build-and-test-local.sh
+++ b/docker/build/build-and-test-local.sh
@@ -5,9 +5,14 @@
 set -euo pipefail
 
 # Colors
+RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
 
 log_info() {
     echo -e "${GREEN}[INFO]${NC} $1"
@@ -22,35 +27,67 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 IMAGE_TAG="${1:-kalamdb:local}"
 
+detect_linux_target() {
+    case "$(uname -m)" in
+        x86_64|amd64)
+            echo "x86_64-unknown-linux-gnu linux/amd64 binaries-amd64"
+            ;;
+        arm64|aarch64)
+            echo "aarch64-unknown-linux-gnu linux/arm64 binaries-arm64"
+            ;;
+        *)
+            log_error "Unsupported host architecture: $(uname -m)"
+            exit 1
+            ;;
+    esac
+}
+
 main() {
     log_info "Building and testing KalamDB Docker image locally"
     log_info "Image tag: $IMAGE_TAG"
     log_info "Project root: $PROJECT_ROOT"
     
     cd "$PROJECT_ROOT"
+
+    read -r LINUX_TARGET DOCKER_PLATFORM BINARIES_DIR <<< "$(detect_linux_target)"
+    BINARY_OUTPUT_DIR="target/$LINUX_TARGET/release"
+    BUILD_TOOL="cargo"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        if ! command -v cross >/dev/null 2>&1; then
+            log_error "cross is required on macOS to build Linux binaries for Docker images"
+            exit 1
+        fi
+        BUILD_TOOL="cross"
+    fi
+
+    log_info "Local Docker platform: $DOCKER_PLATFORM"
+    log_info "Linux target: $LINUX_TARGET"
     
-    # Step 1: Build release binaries
-    log_info "Step 1/4: Building release binaries..."
-    if [ ! -f "target/release/kalamdb-server" ] || [ ! -f "target/release/kalam" ]; then
-        log_info "Building with cargo (this may take a while)..."
-        cargo build --release --features mimalloc -p kalamdb-server -p kalam-cli --bin kalamdb-server --bin kalam
+    # Step 1: Build Linux release binaries
+    log_info "Step 1/4: Building Linux release binaries..."
+    rustup target add "$LINUX_TARGET" >/dev/null
+    if [ ! -f "$BINARY_OUTPUT_DIR/kalamdb-server" ] || [ ! -f "$BINARY_OUTPUT_DIR/kalam" ]; then
+        log_info "Building with $BUILD_TOOL (this may take a while)..."
+        SKIP_UI_BUILD=1 "$BUILD_TOOL" build --release --target "$LINUX_TARGET" --features mimalloc -p kalamdb-server -p kalam-cli --bin kalamdb-server --bin kalam
     else
-        log_warn "Using existing release binaries (run 'cargo clean' to rebuild)"
+        log_warn "Using existing Linux binaries from $BINARY_OUTPUT_DIR"
     fi
     
     # Step 2: Prepare binaries directory
     log_info "Step 2/4: Preparing binaries directory..."
-    mkdir -p binaries-amd64
-    cp target/release/kalamdb-server binaries-amd64/
-    cp target/release/kalam binaries-amd64/
-    chmod +x binaries-amd64/kalamdb-server binaries-amd64/kalam
+    rm -rf "$BINARIES_DIR"
+    mkdir -p "$BINARIES_DIR"
+    cp "$BINARY_OUTPUT_DIR/kalamdb-server" "$BINARIES_DIR/"
+    cp "$BINARY_OUTPUT_DIR/kalam" "$BINARIES_DIR/"
+    chmod +x "$BINARIES_DIR/kalamdb-server" "$BINARIES_DIR/kalam"
     log_info "Binaries ready:"
-    ls -lh binaries-amd64/
+    ls -lh "$BINARIES_DIR/"
     
     # Step 3: Build Docker image
     log_info "Step 3/4: Building Docker image..."
     docker build \
-        --build-context binaries=binaries-amd64 \
+        --platform "$DOCKER_PLATFORM" \
+        --build-context binaries="$BINARIES_DIR" \
         -f docker/build/Dockerfile.prebuilt \
         -t "$IMAGE_TAG" \
         .
@@ -61,11 +98,11 @@ main() {
     # Step 4: Run smoke tests
     log_info "Step 4/4: Running smoke tests..."
     chmod +x docker/build/test-docker-image.sh
-    ./docker/build/test-docker-image.sh "$IMAGE_TAG"
+    DOCKER_PLATFORM="$DOCKER_PLATFORM" ./docker/build/test-docker-image.sh "$IMAGE_TAG"
     
     # Cleanup
     log_info "Cleaning up binaries directory..."
-    rm -rf binaries-amd64
+    rm -rf "$BINARIES_DIR"
     
     log_info ""
     log_info "========================================="

--- a/docker/build/test-docker-image.sh
+++ b/docker/build/test-docker-image.sh
@@ -21,6 +21,16 @@ EXPECTED_OCI_VERSION="${EXPECTED_OCI_VERSION:-}"
 EXPECTED_OCI_SOURCE="${EXPECTED_OCI_SOURCE:-}"
 EXPECTED_RUNTIME_UID="${EXPECTED_RUNTIME_UID:-65532}"
 
+if [[ -z "${KALAMDB_JWT_SECRET:-}" ]]; then
+    if command -v openssl >/dev/null 2>&1; then
+        KALAMDB_JWT_SECRET="$(openssl rand -base64 32 | tr -d '\n')"
+        export KALAMDB_JWT_SECRET
+    else
+        KALAMDB_JWT_SECRET="local-test-jwt-secret-0123456789abcdef0123456789abcdef"
+        export KALAMDB_JWT_SECRET
+    fi
+fi
+
 log_info() {
     echo -e "${GREEN}[INFO]${NC} $1"
 }
@@ -35,7 +45,7 @@ log_warn() {
 
 container_get() {
     local path="$1"
-    docker exec "$CONTAINER_NAME" /usr/local/bin/busybox wget -qO- "http://127.0.0.1:8080${path}"
+    docker exec "$CONTAINER_NAME" /bin/busybox wget -qO- "http://127.0.0.1:8080${path}"
 }
 
 cleanup() {
@@ -87,18 +97,14 @@ main() {
         -e KALAMDB_SERVER_HOST=0.0.0.0
         -e KALAMDB_LOG_LEVEL=info
         -e KALAMDB_ROOT_PASSWORD="$ROOT_PASSWORD"
+        -e KALAMDB_JWT_SECRET="$KALAMDB_JWT_SECRET"
     )
 
     if [[ -n "$DOCKER_PLATFORM" ]]; then
         DOCKER_RUN_ARGS+=(--platform "$DOCKER_PLATFORM")
     fi
 
-    if [ -n "${KALAMDB_JWT_SECRET:-}" ]; then
-        DOCKER_RUN_ARGS+=(-e "KALAMDB_JWT_SECRET=${KALAMDB_JWT_SECRET}")
-        docker run "${DOCKER_RUN_ARGS[@]}" "$IMAGE_NAME"
-    else
-        docker run "${DOCKER_RUN_ARGS[@]}" "$IMAGE_NAME"
-    fi
+    docker run "${DOCKER_RUN_ARGS[@]}" "$IMAGE_NAME"
     
     log_info "Waiting for server to start (timeout: ${TIMEOUT}s)..."
     START_TIME=$(date +%s)
@@ -120,7 +126,7 @@ main() {
             exit 1
         fi
         
-        if docker exec "$CONTAINER_NAME" /usr/local/bin/busybox wget -q -O /dev/null "http://127.0.0.1:8080/health" > /dev/null 2>&1; then
+        if docker exec "$CONTAINER_NAME" /bin/busybox wget -q -O /dev/null "http://127.0.0.1:8080/health" > /dev/null 2>&1; then
             log_info "Server is ready! (took ${ELAPSED}s)"
             break
         fi
@@ -150,13 +156,13 @@ main() {
     
     # Test 3: Runtime user and writable paths
     log_info "Test 3: Checking runtime user and writable paths..."
-    RUNTIME_UID=$(docker exec "$CONTAINER_NAME" /usr/local/bin/busybox sh -c 'id -u')
+    RUNTIME_UID=$(docker exec "$CONTAINER_NAME" /bin/busybox sh -c 'id -u')
     if [[ "$RUNTIME_UID" != "$EXPECTED_RUNTIME_UID" ]]; then
         log_error "✗ Container is running as unexpected uid: $RUNTIME_UID"
         exit 1
     fi
 
-    docker exec "$CONTAINER_NAME" /usr/local/bin/busybox sh -c 'test -f /config/server.toml && test -d /data && test -w /data && mkdir -p /data/.kalam && touch /data/.kalam/write-test && rm /data/.kalam/write-test' &>/dev/null
+    docker exec "$CONTAINER_NAME" /bin/busybox sh -c 'test -f /config/server.toml && test -d /data && test -w /data && mkdir -p /data/.kalam && touch /data/.kalam/write-test && rm /data/.kalam/write-test' &>/dev/null
     if [ $? -eq 0 ]; then
         log_info "✓ Runtime paths are present and writable"
     else
@@ -166,7 +172,7 @@ main() {
 
     # Test 4: Check binary existence
     log_info "Test 4: Checking binaries inside container..."
-    docker exec "$CONTAINER_NAME" /usr/local/bin/busybox sh -c "test -x /usr/local/bin/kalamdb-server" &>/dev/null
+    docker exec "$CONTAINER_NAME" /bin/busybox sh -c "test -x /usr/local/bin/kalamdb-server" &>/dev/null
     if [ $? -eq 0 ]; then
         log_info "✓ Server binary exists and is executable"
     else


### PR DESCRIPTION
Add multi-architecture local build support and modernize prebuilt Docker image. Updates README build instructions to detect host architecture and build or cross-build Linux-targeted binaries (amd64/arm64), stage them into a platform-specific binaries directory, and pass --platform to docker build. Dockerfile.prebuilt was refactored to use smaller debian:bookworm-slim stages, unified binary handling/stripping, create a non-root kalamdb user, copy runtime assets with correct ownership, and adjust busybox paths and runtime tooling. build-and-test-local.sh now auto-detects target/platform, supports cross on macOS, robustly prepares binaries, and cleans up. test-docker-image.sh generates a JWT secret for local tests, adapts busybox invocation paths, and validates runtime UID and writable paths. Overall these changes improve local multi-arch development, reduce image size, and harden test scripts.
