### PR TITLE
Add Snowflake benchmarks and optimize generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,6 +4073,7 @@ dependencies = [
  "arrow",
  "arrow-schema",
  "chrono",
+ "criterion 0.8.2",
  "dashmap 6.1.0",
  "datafusion-common",
  "flatbuffers",

--- a/backend/crates/kalamdb-commons/Cargo.toml
+++ b/backend/crates/kalamdb-commons/Cargo.toml
@@ -35,6 +35,9 @@ nanoid = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+criterion = { workspace = true }
+
 [features]
 # Feature to enable serde support for serialization
 serde = [
@@ -97,3 +100,7 @@ default = ["full"]
 [lib]
 name = "kalamdb_commons"
 path = "src/lib.rs"
+
+[[bench]]
+name = "snowflake_generator"
+harness = false

--- a/backend/crates/kalamdb-commons/benches/snowflake_generator.rs
+++ b/backend/crates/kalamdb-commons/benches/snowflake_generator.rs
@@ -1,0 +1,257 @@
+use std::{
+    hint::black_box,
+    sync::{atomic::{AtomicU64, Ordering}, Arc},
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use criterion::{
+    criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use kalamdb_commons::ids::SnowflakeGenerator;
+use parking_lot::Mutex;
+
+const SINGLE_BURST_SIZE: usize = 1024;
+
+struct LegacySnowflakeGenerator {
+    worker_bits: u64,
+    epoch: u64,
+    state: Mutex<LegacyGeneratorState>,
+}
+
+struct LegacyGeneratorState {
+    last_timestamp: u64,
+    sequence: u16,
+}
+
+impl LegacySnowflakeGenerator {
+    const DEFAULT_EPOCH: u64 = SnowflakeGenerator::DEFAULT_EPOCH;
+    const MAX_SEQUENCE: u16 = 4095;
+    const MAX_BACKWARD_DRIFT_MS: u64 = 50;
+
+    fn new(worker_id: u16) -> Self {
+        Self {
+            worker_bits: (worker_id as u64) << 12,
+            epoch: Self::DEFAULT_EPOCH,
+            state: Mutex::new(LegacyGeneratorState {
+                last_timestamp: 0,
+                sequence: 0,
+            }),
+        }
+    }
+
+    fn next_id(&self) -> Result<i64, String> {
+        let mut state = self.state.lock();
+
+        let mut timestamp = self.reconcile_timestamp(state.last_timestamp)?;
+
+        if timestamp == state.last_timestamp {
+            state.sequence = (state.sequence + 1) & Self::MAX_SEQUENCE;
+            if state.sequence == 0 {
+                timestamp = self.wait_next_millis(state.last_timestamp)?;
+            }
+        } else {
+            state.sequence = 0;
+        }
+
+        state.last_timestamp = timestamp;
+        Ok(self.compose_id(timestamp, state.sequence as u64))
+    }
+
+    fn next_ids(&self, count: usize) -> Result<Vec<i64>, String> {
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut state = self.state.lock();
+        let mut ids = Vec::with_capacity(count);
+
+        for _ in 0..count {
+            let mut timestamp = self.reconcile_timestamp(state.last_timestamp)?;
+
+            if timestamp == state.last_timestamp {
+                state.sequence = (state.sequence + 1) & Self::MAX_SEQUENCE;
+                if state.sequence == 0 {
+                    timestamp = self.wait_next_millis(state.last_timestamp)?;
+                }
+            } else {
+                state.sequence = 0;
+            }
+
+            state.last_timestamp = timestamp;
+            ids.push(self.compose_id(timestamp, state.sequence as u64));
+        }
+
+        Ok(ids)
+    }
+
+    fn current_timestamp(&self) -> Result<u64, String> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .map_err(|e| format!("Failed to get current timestamp: {}", e))
+    }
+
+    fn wait_next_millis(&self, last_timestamp: u64) -> Result<u64, String> {
+        let mut timestamp = self.current_timestamp()?;
+        while timestamp <= last_timestamp {
+            timestamp = self.current_timestamp()?;
+        }
+        Ok(timestamp)
+    }
+
+    fn reconcile_timestamp(&self, last_timestamp: u64) -> Result<u64, String> {
+        let timestamp = self.current_timestamp()?;
+        if timestamp >= last_timestamp {
+            return Ok(timestamp);
+        }
+
+        let drift_ms = last_timestamp - timestamp;
+        if drift_ms > Self::MAX_BACKWARD_DRIFT_MS {
+            return Err(format!(
+                "Clock moved backwards. Refusing to generate id for {} milliseconds",
+                drift_ms
+            ));
+        }
+
+        thread::sleep(Duration::from_millis(drift_ms));
+        self.wait_next_millis(last_timestamp)
+    }
+
+    fn compose_id(&self, timestamp: u64, sequence: u64) -> i64 {
+        (((timestamp - self.epoch) << 22) | self.worker_bits | sequence) as i64
+    }
+}
+
+fn bench_single_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("snowflake_single_generation");
+    group.throughput(Throughput::Elements(SINGLE_BURST_SIZE as u64));
+
+    group.bench_function(BenchmarkId::new("optimized", "single"), |b| {
+        b.iter_batched(
+            || SnowflakeGenerator::new(1),
+            |generator| {
+                for _ in 0..SINGLE_BURST_SIZE {
+                    black_box(generator.next_id().expect("optimized next_id"));
+                }
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("legacy", "single"), |b| {
+        b.iter_batched(
+            || LegacySnowflakeGenerator::new(1),
+            |generator| {
+                for _ in 0..SINGLE_BURST_SIZE {
+                    black_box(generator.next_id().expect("legacy next_id"));
+                }
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_batch_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("snowflake_batch_generation");
+
+    for batch_size in [32_usize, 256, 1024] {
+        group.throughput(Throughput::Elements(batch_size as u64));
+
+        group.bench_with_input(BenchmarkId::new("optimized", batch_size), &batch_size, |b, &size| {
+            b.iter_batched(
+                || SnowflakeGenerator::new(1),
+                |generator| black_box(generator.next_ids(size).expect("optimized next_ids")),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("legacy", batch_size), &batch_size, |b, &size| {
+            b.iter_batched(
+                || LegacySnowflakeGenerator::new(1),
+                |generator| black_box(generator.next_ids(size).expect("legacy next_ids")),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_single_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("snowflake_concurrent_single_generation");
+    let thread_count = 8;
+    let ids_per_thread = 1_000;
+    group.throughput(Throughput::Elements((thread_count * ids_per_thread) as u64));
+
+    group.bench_function(BenchmarkId::new("optimized", format!("{}x{}", thread_count, ids_per_thread)), |b| {
+        b.iter(|| {
+            let generator = Arc::new(SnowflakeGenerator::new(1));
+            let duplicates = Arc::new(AtomicU64::new(0));
+            thread::scope(|scope| {
+                let mut handles = Vec::with_capacity(thread_count);
+                for _ in 0..thread_count {
+                    let generator = Arc::clone(&generator);
+                    let duplicates = Arc::clone(&duplicates);
+                    handles.push(scope.spawn(move || {
+                        let mut prev = None;
+                        for _ in 0..ids_per_thread {
+                            let next = generator.next_id().expect("optimized concurrent next_id");
+                            if let Some(prev) = prev {
+                                if next <= prev {
+                                    duplicates.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                            prev = Some(next);
+                        }
+                    }));
+                }
+                for handle in handles {
+                    handle.join().expect("optimized thread join");
+                }
+            });
+            assert_eq!(duplicates.load(Ordering::Relaxed), 0);
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("legacy", format!("{}x{}", thread_count, ids_per_thread)), |b| {
+        b.iter(|| {
+            let generator = Arc::new(LegacySnowflakeGenerator::new(1));
+            let duplicates = Arc::new(AtomicU64::new(0));
+            thread::scope(|scope| {
+                let mut handles = Vec::with_capacity(thread_count);
+                for _ in 0..thread_count {
+                    let generator = Arc::clone(&generator);
+                    let duplicates = Arc::clone(&duplicates);
+                    handles.push(scope.spawn(move || {
+                        let mut prev = None;
+                        for _ in 0..ids_per_thread {
+                            let next = generator.next_id().expect("legacy concurrent next_id");
+                            if let Some(prev) = prev {
+                                if next <= prev {
+                                    duplicates.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                            prev = Some(next);
+                        }
+                    }));
+                }
+                for handle in handles {
+                    handle.join().expect("legacy thread join");
+                }
+            });
+            assert_eq!(duplicates.load(Ordering::Relaxed), 0);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(20).warm_up_time(Duration::from_millis(500));
+    targets = bench_single_generation, bench_batch_generation, bench_concurrent_single_generation
+);
+criterion_main!(benches);

--- a/backend/crates/kalamdb-commons/src/ids/snowflake.rs
+++ b/backend/crates/kalamdb-commons/src/ids/snowflake.rs
@@ -10,22 +10,22 @@ use parking_lot::Mutex;
 /// - 10 bits: machine/worker ID
 /// - 12 bits: sequence number
 pub struct SnowflakeGenerator {
-    /// Machine/worker ID (0-1023)
-    worker_id: u16,
+    /// Pre-shifted worker bits reused for every emitted ID.
+    worker_bits: u64,
 
     /// Custom epoch (milliseconds since Unix epoch)
     /// Default: 2024-01-01 00:00:00 UTC (1704067200000)
     epoch: u64,
 
-    /// State protected by mutex
+    /// Mutable generator state protected by a lightweight mutex.
     state: Mutex<GeneratorState>,
 }
 
 struct GeneratorState {
-    /// Last timestamp used
+    /// Last timestamp used.
     last_timestamp: u64,
 
-    /// Sequence number (0-4095)
+    /// Last sequence emitted for `last_timestamp`.
     sequence: u16,
 }
 
@@ -33,6 +33,9 @@ impl SnowflakeGenerator {
     /// Custom epoch: 2024-01-01 00:00:00 UTC
     pub const DEFAULT_EPOCH: u64 = 1704067200000;
 
+    const TIMESTAMP_SHIFT: u32 = 22;
+
+        const SEQUENCE_BITS: u32 = 12;
     /// Maximum worker ID
     pub const MAX_WORKER_ID: u16 = 1023;
 
@@ -53,7 +56,7 @@ impl SnowflakeGenerator {
         assert!(worker_id <= Self::MAX_WORKER_ID, "worker_id must be <= {}", Self::MAX_WORKER_ID);
 
         Self {
-            worker_id,
+            worker_bits: (worker_id as u64) << Self::SEQUENCE_BITS,
             epoch,
             state: Mutex::new(GeneratorState {
                 last_timestamp: 0,
@@ -63,35 +66,27 @@ impl SnowflakeGenerator {
     }
 
     /// Generate the next Snowflake ID
+    #[inline]
     pub fn next_id(&self) -> Result<i64, String> {
         let mut state = self.state.lock();
-
-        let mut timestamp = self.reconcile_timestamp(&state)?;
+        let mut timestamp = self.reconcile_timestamp(state.last_timestamp)?;
 
         if timestamp == state.last_timestamp {
-            // Same millisecond - increment sequence
             state.sequence = (state.sequence + 1) & Self::MAX_SEQUENCE;
 
             if state.sequence == 0 {
-                // Sequence overflow - wait for next millisecond
                 timestamp = self.wait_next_millis(state.last_timestamp)?;
             }
         } else {
-            // New millisecond - reset sequence
             state.sequence = 0;
         }
 
         state.last_timestamp = timestamp;
-
-        // Construct the ID
-        let id = ((timestamp - self.epoch) << 22)
-            | ((self.worker_id as u64) << 12)
-            | (state.sequence as u64);
-
-        Ok(id as i64)
+        Ok(self.compose_id(timestamp, state.sequence as u64))
     }
 
     /// Get current timestamp in milliseconds
+    #[inline]
     fn current_timestamp(&self) -> Result<u64, String> {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -125,6 +120,7 @@ impl SnowflakeGenerator {
     }
 
     /// Wait until next millisecond
+    #[inline]
     fn wait_next_millis(&self, last_timestamp: u64) -> Result<u64, String> {
         let mut timestamp = self.current_timestamp()?;
         while timestamp <= last_timestamp {
@@ -161,6 +157,7 @@ impl SnowflakeGenerator {
     ///
     /// # Returns
     /// Vector of unique, time-ordered Snowflake IDs
+    #[inline]
     pub fn next_ids(&self, count: usize) -> Result<Vec<i64>, String> {
         if count == 0 {
             return Ok(Vec::new());
@@ -169,42 +166,44 @@ impl SnowflakeGenerator {
         let mut state = self.state.lock();
         let mut ids = Vec::with_capacity(count);
 
-        for _ in 0..count {
-            let mut timestamp = self.reconcile_timestamp(&state)?;
+        while ids.len() < count {
+            let remaining = count - ids.len();
 
-            if timestamp == state.last_timestamp {
-                // Same millisecond - increment sequence
-                state.sequence = (state.sequence + 1) & Self::MAX_SEQUENCE;
-
-                if state.sequence == 0 {
-                    // Sequence overflow - wait for next millisecond
+            let mut timestamp = self.reconcile_timestamp(state.last_timestamp)?;
+            let (start_sequence, chunk_len) = if timestamp == state.last_timestamp {
+                if state.sequence == Self::MAX_SEQUENCE {
                     timestamp = self.wait_next_millis(state.last_timestamp)?;
+                    let chunk_len = remaining.min((Self::MAX_SEQUENCE as usize) + 1);
+                    state.sequence = (chunk_len - 1) as u16;
+                    (0_u64, chunk_len)
+                } else {
+                    let available = (Self::MAX_SEQUENCE - state.sequence) as usize;
+                    let chunk_len = remaining.min(available);
+                    let start_sequence = state.sequence as u64 + 1;
+                    state.sequence += chunk_len as u16;
+                    (start_sequence, chunk_len)
                 }
             } else {
-                // New millisecond - reset sequence
-                state.sequence = 0;
-            }
+                let chunk_len = remaining.min((Self::MAX_SEQUENCE as usize) + 1);
+                state.sequence = (chunk_len - 1) as u16;
+                (0_u64, chunk_len)
+            };
 
             state.last_timestamp = timestamp;
-
-            // Construct the ID
-            let id = ((timestamp - self.epoch) << 22)
-                | ((self.worker_id as u64) << 12)
-                | (state.sequence as u64);
-
-            ids.push(id as i64);
+            self.append_chunk_ids(&mut ids, timestamp, start_sequence, chunk_len);
         }
 
         Ok(ids)
     }
 
-    fn reconcile_timestamp(&self, state: &GeneratorState) -> Result<u64, String> {
+    #[inline]
+    fn reconcile_timestamp(&self, last_timestamp: u64) -> Result<u64, String> {
         let timestamp = self.current_timestamp()?;
-        if timestamp >= state.last_timestamp {
+        if timestamp >= last_timestamp {
             return Ok(timestamp);
         }
 
-        let drift_ms = state.last_timestamp - timestamp;
+        let drift_ms = last_timestamp - timestamp;
         if drift_ms > Self::MAX_BACKWARD_DRIFT_MS {
             return Err(format!(
                 "Clock moved backwards. Refusing to generate id for {} milliseconds",
@@ -213,7 +212,24 @@ impl SnowflakeGenerator {
         }
 
         std::thread::sleep(Duration::from_millis(drift_ms));
-        self.wait_next_millis(state.last_timestamp)
+        self.wait_next_millis(last_timestamp)
+    }
+
+    #[inline]
+    fn compose_id(&self, timestamp: u64, sequence: u64) -> i64 {
+        (((timestamp - self.epoch) << Self::TIMESTAMP_SHIFT) | self.worker_bits | sequence) as i64
+    }
+
+    fn append_chunk_ids(
+        &self,
+        ids: &mut Vec<i64>,
+        timestamp: u64,
+        start_sequence: u64,
+        chunk_len: usize,
+    ) {
+        for offset in 0..chunk_len {
+            ids.push(self.compose_id(timestamp, start_sequence + offset as u64));
+        }
     }
 }
 
@@ -458,5 +474,39 @@ mod tests {
         all_ids.insert(batch_ids[1]);
         all_ids.insert(batch_ids[2]);
         assert_eq!(all_ids.len(), 4, "All IDs must be unique");
+    }
+
+    #[test]
+    fn test_concurrent_single_and_batch_generation() {
+        use std::{sync::Arc, thread};
+
+        let gen = Arc::new(SnowflakeGenerator::new(7));
+        let mut handles = Vec::new();
+
+        for _ in 0..4 {
+            let gen_clone = Arc::clone(&gen);
+            handles.push(thread::spawn(move || {
+                let mut ids = Vec::new();
+                for _ in 0..250 {
+                    ids.push(gen_clone.next_id().unwrap());
+                }
+                ids
+            }));
+        }
+
+        for _ in 0..4 {
+            let gen_clone = Arc::clone(&gen);
+            handles.push(thread::spawn(move || gen_clone.next_ids(250).unwrap()));
+        }
+
+        let mut all_ids = HashSet::new();
+        for handle in handles {
+            let ids = handle.join().unwrap();
+            for id in ids {
+                assert!(all_ids.insert(id), "Duplicate ID in mixed concurrency test");
+            }
+        }
+
+        assert_eq!(all_ids.len(), 2000);
     }
 }

--- a/docker/build/Dockerfile.prebuilt
+++ b/docker/build/Dockerfile.prebuilt
@@ -28,6 +28,30 @@ RUN chmod 755 /staged/usr/local/bin/* && \
 # ---------- Stage 3: final runtime ----------
 FROM debian:bookworm-slim
 
+ARG OCI_IMAGE_TITLE="KalamDB"
+ARG OCI_IMAGE_DESCRIPTION="KalamDB database server"
+ARG OCI_IMAGE_URL="https://kalamdb.org"
+ARG OCI_IMAGE_SOURCE="https://github.com/kalamstack/KalamDB"
+ARG OCI_IMAGE_DOCUMENTATION="https://kalamdb.org/docs"
+ARG OCI_IMAGE_VENDOR="KalamDB"
+ARG OCI_IMAGE_AUTHORS="Jamal Saad"
+ARG OCI_IMAGE_LICENSES="Apache-2.0"
+ARG OCI_IMAGE_VERSION="dev"
+ARG OCI_IMAGE_REVISION="unknown"
+ARG OCI_IMAGE_CREATED="unknown"
+
+LABEL org.opencontainers.image.title="$OCI_IMAGE_TITLE" \
+      org.opencontainers.image.description="$OCI_IMAGE_DESCRIPTION" \
+      org.opencontainers.image.url="$OCI_IMAGE_URL" \
+      org.opencontainers.image.source="$OCI_IMAGE_SOURCE" \
+      org.opencontainers.image.documentation="$OCI_IMAGE_DOCUMENTATION" \
+      org.opencontainers.image.vendor="$OCI_IMAGE_VENDOR" \
+      org.opencontainers.image.authors="$OCI_IMAGE_AUTHORS" \
+      org.opencontainers.image.licenses="$OCI_IMAGE_LICENSES" \
+      org.opencontainers.image.version="$OCI_IMAGE_VERSION" \
+      org.opencontainers.image.revision="$OCI_IMAGE_REVISION" \
+      org.opencontainers.image.created="$OCI_IMAGE_CREATED"
+
 RUN apt-get update -o Acquire::Retries=3 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates bash busybox-static && \


### PR DESCRIPTION
Add Criterion benchmarks for the Snowflake ID generator (single, batch, concurrent) and register a bench target in kalamdb-commons. Refactor SnowflakeGenerator to precompute worker bits, introduce timestamp/sequence constants, inline hot functions, and optimize next_ids to emit per-millisecond chunks (reducing overhead and locking). Add helper methods (compose_id, append_chunk_ids), adjust timestamp reconciliation, and include a mixed concurrency test. Also add OCI image metadata labels/args to the prebuilt Dockerfile and add criterion as a dev-dependency/bench configuration.
