### PR TITLE
Add auto-fetch batch control for live subscriptions

### DIFF
--- a/backend/crates/kalamdb-core/src/sql/impersonation.rs
+++ b/backend/crates/kalamdb-core/src/sql/impersonation.rs
@@ -87,15 +87,6 @@ impl SqlImpersonationService {
             .role_for_impersonation_target(&target_user_id);
 
         if can_impersonate_target_user(actor_user_id, actor_role, &target_user_id, target_role) {
-            self.audit_impersonation_event(
-                actor_user_id,
-                actor_role,
-                target_user_id.as_str(),
-                Some(&target_user_id),
-                true,
-                None,
-            )
-            .await;
             return Ok(target_user_id);
         }
 

--- a/backend/tests/misc/auth/test_as_user_impersonation.rs
+++ b/backend/tests/misc/auth/test_as_user_impersonation.rs
@@ -365,6 +365,41 @@ async fn test_allowed_execute_as_can_select_update_and_delete_target_rows() {
 
 #[actix_web::test]
 #[ntest::timeout(45000)]
+async fn test_allowed_execute_as_dml_is_not_audited() {
+    let server = TestServer::new_shared().await;
+    let ns = unique_name("as_user_dml_no_audit");
+    create_user_table(&server, &ns, "profiles").await;
+
+    let actor = insert_user(&server, &unique_name("no_audit_actor"), Role::Dba).await;
+    let target = insert_user(&server, &unique_name("no_audit_target"), Role::User).await;
+
+    let insert_sql = format!(
+        "EXECUTE AS USER '{}' (INSERT INTO {}.profiles (id, value) VALUES ('p1', 'delegated'))",
+        target.as_str(),
+        ns
+    );
+    let insert_resp = server.execute_sql_as_user(&insert_sql, actor.as_str()).await;
+    assert_success(&insert_resp, "allowed cross-user insert without audit");
+
+    let logs = server
+        .app_context
+        .system_tables()
+        .audit_logs()
+        .scan_all()
+        .expect("Failed to read audit log");
+    assert!(
+        !logs.iter().any(|entry| {
+            entry.action == "EXECUTE_AS_USER"
+                && entry.target == format!("user:{}", target.as_str())
+                && entry.actor_user_id == actor
+                && entry.subject_user_id.as_ref() == Some(&target)
+        }),
+        "successful execute as DML should not create an audit entry"
+    );
+}
+
+#[actix_web::test]
+#[ntest::timeout(45000)]
 async fn test_execute_as_stream_table_uses_target_user_scope() {
     let server = TestServer::new_shared().await;
     let ns = unique_name("as_user_stream_scope");

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -24,8 +24,8 @@ use indicatif::{ProgressBar, ProgressStyle};
 use kalam_client::{
     credentials::{CredentialStore, Credentials},
     AuthProvider, AuthRefreshCallback, ClusterHealthResponse, ClusterNodeHealth, ConnectionOptions,
-    KalamLinkClient, KalamLinkError, KalamLinkTimeouts, SubscriptionConfig, SubscriptionOptions,
-    TimestampFormatter, UploadProgress, UploadProgressCallback,
+    KalamLinkClient, KalamLinkError, KalamLinkTimeouts, SeqId, SubscriptionConfig,
+    SubscriptionOptions, TimestampFormatter, UploadProgress, UploadProgressCallback,
 };
 use rustyline::{
     completion::Completer, error::ReadlineError, highlight::Highlighter, hint::Hinter,
@@ -1703,8 +1703,8 @@ impl CLISession {
 
     /// Extract OPTIONS clause from SUBSCRIBE SQL query.
     ///
-    /// Parses `OPTIONS (last_rows=N)` from the SQL and returns cleaned SQL + options.
-    /// If no OPTIONS found, returns original SQL with default options (last_rows=100).
+    /// Parses CLI-managed options from `OPTIONS (...)` and returns cleaned SQL + options.
+    /// If no OPTIONS found, returns original SQL with default subscription options.
     ///
     /// # Examples
     /// ```
@@ -1728,48 +1728,63 @@ impl CLISession {
         let clean_sql = sql[..idx].trim().to_string();
         let options_str = sql[idx + " OPTIONS".len()..].trim(); // " OPTIONS".len() == 8
 
-        // Parse OPTIONS (last_rows=N)
+        // Parse CLI-managed options from OPTIONS (...)
         let options = Self::parse_subscribe_options(options_str);
 
         (clean_sql, options)
     }
 
-    /// Parse OPTIONS clause value: (last_rows=N)
+    /// Parse OPTIONS clause value: (last_rows=N, batch_size=N, from=N)
     fn parse_subscribe_options(options_str: &str) -> Option<SubscriptionOptions> {
         let options_str = options_str.trim();
 
-        // Expected format: (last_rows=N) or ( last_rows = N )
+        // Expected format: (last_rows=N, batch_size=N, from=N)
         if !options_str.starts_with('(') || !options_str.ends_with(')') {
             eprintln!("Warning: Invalid OPTIONS format, using defaults");
             return Some(SubscriptionOptions::default());
         }
 
         let inner = options_str[1..options_str.len() - 1].trim();
+        let mut options = SubscriptionOptions::new();
 
-        // Parse last_rows=N
-        if let Some(equals_idx) = inner.find('=') {
-            let key = inner[..equals_idx].trim();
-            let value = inner[equals_idx + 1..].trim();
+        for pair in inner.split(',') {
+            let pair = pair.trim();
+            if pair.is_empty() {
+                continue;
+            }
 
-            if key.to_lowercase() == "last_rows" {
+            let Some((key, value)) = pair.split_once('=') else {
+                eprintln!("Warning: Invalid option '{}', expected key=value", pair);
+                continue;
+            };
+
+            let key = key.trim().to_ascii_lowercase();
+            let value = value.trim().trim_matches(['\'', '"']);
+
+            if key == "last_rows" {
                 if let Ok(last_rows) = value.parse::<u32>() {
-                    return Some(SubscriptionOptions::new().with_last_rows(last_rows));
+                    options = options.with_last_rows(last_rows);
                 } else {
                     eprintln!("Warning: Invalid last_rows value '{}', using default", value);
                 }
-            } else if key.to_lowercase() == "batch_size" {
+            } else if key == "batch_size" {
                 if let Ok(batch_size) = value.parse::<usize>() {
-                    return Some(SubscriptionOptions::new().with_batch_size(batch_size));
+                    options = options.with_batch_size(batch_size);
                 } else {
                     eprintln!("Warning: Invalid batch_size value '{}', using default", value);
+                }
+            } else if key == "from" || key == "from_seq_id" {
+                if let Ok(seq_id) = value.parse::<i64>() {
+                    options = options.with_from(SeqId::from(seq_id));
+                } else {
+                    eprintln!("Warning: Invalid from value '{}', using default", value);
                 }
             } else {
                 eprintln!("Warning: Unknown option '{}', ignoring", key);
             }
         }
 
-        // Default if parsing failed
-        Some(SubscriptionOptions::default())
+        Some(options)
     }
 
     /// Run a WebSocket subscription
@@ -2286,9 +2301,9 @@ impl CLISession {
                     );
                 }
 
-                // Display rows in the same format as snapshots
+                // Keep startup rows compact so each payload stays on a single CLI line.
                 for row in rows {
-                    let formatted = serde_json::to_string_pretty(&row).unwrap_or_default();
+                    let formatted = Self::format_row(row);
                     if self.color {
                         println!("  \x1b[90m{}\x1b[0m", formatted);
                     } else {
@@ -3516,7 +3531,55 @@ mod tests {
         let (sql, options) =
             CLISession::extract_subscribe_options("SELECT * FROM table OPTIONS (last_rows=50);");
         assert_eq!(sql, "SELECT * FROM table");
-        assert!(options.is_some());
+        let options = options.expect("options should parse");
+        assert_eq!(options.last_rows, Some(50));
+    }
+
+    #[test]
+    fn test_extract_subscribe_options_with_combined_options() {
+        let (sql, options) = CLISession::extract_subscribe_options(
+            "SELECT * FROM table OPTIONS (last_rows=20, batch_size=5, from=42);",
+        );
+
+        assert_eq!(sql, "SELECT * FROM table");
+        let options = options.expect("options should parse");
+        assert_eq!(options.last_rows, Some(20));
+        assert_eq!(options.batch_size, Some(5));
+        assert_eq!(options.from, Some(SeqId::from(42)));
+    }
+
+    #[test]
+    fn test_extract_subscribe_options_accepts_from_seq_id_alias() {
+        let (sql, options) = CLISession::extract_subscribe_options(
+            "SELECT * FROM table OPTIONS (batch_size=10, from_seq_id=99);",
+        );
+
+        assert_eq!(sql, "SELECT * FROM table");
+        let options = options.expect("options should parse");
+        assert_eq!(options.batch_size, Some(10));
+        assert_eq!(options.from, Some(SeqId::from(99)));
+    }
+
+    #[test]
+    fn test_format_row_returns_compact_json_without_newlines() {
+        let mut row = kalam_client::RowData::new();
+        row.insert(
+            "message".to_string(),
+            kalam_client::KalamCellValue::text("hello"),
+        );
+        row.insert(
+            "count".to_string(),
+            kalam_client::KalamCellValue::int(5),
+        );
+
+        let formatted = CLISession::format_row(&row);
+
+        assert!(!formatted.contains('\n'));
+        assert!(!formatted.contains("  "));
+        assert!(formatted.starts_with('{'));
+        assert!(formatted.ends_with('}'));
+        assert!(formatted.contains("\"message\":\"hello\""));
+        assert!(formatted.contains("\"count\":5"));
     }
 
     #[test]

--- a/examples/chat-with-ai/chat-app.sql
+++ b/examples/chat-with-ai/chat-app.sql
@@ -23,3 +23,9 @@ CREATE TABLE IF NOT EXISTS chat_demo.agent_events (
     message TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMP NOT NULL DEFAULT NOW()
 ) WITH (TYPE = 'STREAM', TTL_SECONDS = 10);
+
+-- Insert some initial messages into the chat
+INSERT INTO chat_demo.messages (role, author, sender_username, content)
+VALUES 
+  ('user', 'user_1', 'john_doe', 'Hello everyone!'),
+  ('assistant', 'ai_bot', 'assistant', 'Hi John 👋 How can I help?');

--- a/link/kalam-link-dart/src/models.rs
+++ b/link/kalam-link-dart/src/models.rs
@@ -481,6 +481,7 @@ impl DartSubscriptionConfig {
                 batch_size: self.batch_size.map(|v| v as usize),
                 last_rows: self.last_rows.map(|v| v as u32),
                 from: self.from.map(kalam_client::SeqId::new),
+                auto_fetch_batches: None,
             }),
             ws_url: None,
         }

--- a/link/link-common/src/connection/shared/routing.rs
+++ b/link/link-common/src/connection/shared/routing.rs
@@ -65,7 +65,12 @@ pub(super) async fn route_event(
     };
     let event_time_ms = now_ms();
 
-    let auto_request_next_batch = matches!(event, ChangeEvent::InitialDataBatch { .. });
+    let auto_request_next_batch = matches!(event, ChangeEvent::InitialDataBatch { .. })
+        && matched_key
+            .as_ref()
+            .and_then(|key| subs.get(key.as_str(&incoming_sub_id)))
+            .and_then(|entry| entry.options.auto_fetch_batches)
+            .unwrap_or(true);
     let mut next_batch_last_seq = None;
     let mut should_request_next_batch = false;
 

--- a/link/link-common/src/subscription/models/subscription_options.rs
+++ b/link/link-common/src/subscription/models/subscription_options.rs
@@ -39,6 +39,11 @@ pub struct SubscriptionOptions {
     /// Typically set automatically during reconnection to resume from last received event.
     #[serde(skip_serializing_if = "Option::is_none", alias = "from_seq_id")]
     pub from: Option<SeqId>,
+
+    /// Client-side control for automatically requesting subsequent initial data batches.
+    /// Skipped on the wire because the backend only needs batch_size/last_rows/from.
+    #[serde(default, skip_serializing, alias = "autoFetchBatches")]
+    pub auto_fetch_batches: Option<bool>,
 }
 
 impl SubscriptionOptions {
@@ -70,6 +75,12 @@ impl SubscriptionOptions {
     /// Deprecated alias retained for backward compatibility.
     pub fn with_from_seq_id(self, seq_id: SeqId) -> Self {
         self.with_from(seq_id)
+    }
+
+    /// Control whether the client should automatically request subsequent initial data batches.
+    pub fn with_auto_fetch_batches(mut self, enabled: bool) -> Self {
+        self.auto_fetch_batches = Some(enabled);
+        self
     }
 
     /// Check if this has a resume seq_id set.

--- a/link/link-common/src/wasm/client.rs
+++ b/link/link-common/src/wasm/client.rs
@@ -25,9 +25,12 @@ use super::{
     },
     wasm_debug_log,
 };
-use crate::models::{
-    ClientMessage, ConnectionOptions, SerializationType, ServerMessage, SubscriptionOptions,
-    SubscriptionRequest,
+use crate::{
+    models::{
+        ChangeEvent, ClientMessage, ConnectionOptions, SerializationType, ServerMessage,
+        SubscriptionOptions, SubscriptionRequest,
+    },
+    seq_id::SeqId,
 };
 
 #[derive(Serialize)]
@@ -165,7 +168,12 @@ impl KalamClient {
                 "KalamClient: Sending subscribe request - id: {}, sql: {}",
                 subscription_id, sql
             ));
-            if let Err(error) = send_ws_message(ws, &subscribe_msg, self.negotiated_ser.get()) {
+            if let Err(error) = send_ws_message_traced(
+                ws,
+                &subscribe_msg,
+                self.negotiated_ser.get(),
+                &self.on_send_cb,
+            ) {
                 self.subscription_state.borrow_mut().remove(&subscription_id);
                 return Err(error);
             }
@@ -200,6 +208,44 @@ impl KalamClient {
             negotiated_ser: Rc::new(Cell::new(SerializationType::Json)),
         }
     }
+}
+
+fn emit_ws_send(on_send_cb: &Rc<RefCell<Option<js_sys::Function>>>, msg: &ClientMessage) {
+    let Some(cb) = on_send_cb.borrow().as_ref().cloned() else {
+        return;
+    };
+    if let Ok(json) = serde_json::to_string(msg) {
+        let _ = cb.call1(&JsValue::NULL, &JsValue::from_str(&json));
+    }
+}
+
+fn send_ws_message_traced(
+    ws: &WebSocket,
+    msg: &ClientMessage,
+    serialization: SerializationType,
+    on_send_cb: &Rc<RefCell<Option<js_sys::Function>>>,
+) -> Result<(), JsValue> {
+    send_ws_message(ws, msg, serialization)?;
+    emit_ws_send(on_send_cb, msg);
+    Ok(())
+}
+
+fn next_batch_message(subscription_id: &str, last_seq_id: Option<SeqId>) -> ClientMessage {
+    ClientMessage::NextBatch {
+        subscription_id: subscription_id.to_string(),
+        last_seq_id,
+    }
+}
+
+fn send_next_batch_traced(
+    ws: &WebSocket,
+    subscription_id: &str,
+    last_seq_id: Option<SeqId>,
+    serialization: SerializationType,
+    on_send_cb: &Rc<RefCell<Option<js_sys::Function>>>,
+) -> Result<(), JsValue> {
+    let msg = next_batch_message(subscription_id, last_seq_id);
+    send_ws_message_traced(ws, &msg, serialization, on_send_cb)
 }
 
 fn reject_pending_subscriptions(
@@ -242,10 +288,11 @@ struct SubscriptionDispatch {
     payload: Option<String>,
     resolve_subscribe: Option<js_sys::Function>,
     reject_subscribe: Option<(js_sys::Function, String)>,
+    next_batch: Option<(String, Option<SeqId>)>,
 }
 
 impl SubscriptionDispatch {
-    fn invoke(self) {
+    fn invoke(self) -> Option<(String, Option<SeqId>)> {
         if let Some(cb) = self.callback {
             if let Some(payload) = self.payload {
                 let _ = cb.call1(&JsValue::NULL, &JsValue::from_str(&payload));
@@ -257,6 +304,7 @@ impl SubscriptionDispatch {
         if let Some((reject, reason)) = self.reject_subscribe {
             let _ = reject.call1(&JsValue::NULL, &JsValue::from_str(&reason));
         }
+        self.next_batch
     }
 }
 
@@ -357,6 +405,7 @@ fn dispatch_subscription_server_message(
     let mut payload = None;
     let mut resolve_subscribe = None;
     let mut reject_subscribe = None;
+    let mut next_batch = None;
     let mut remove_state = false;
 
     {
@@ -366,6 +415,11 @@ fn dispatch_subscription_server_message(
             if let Some(filtered_event) = filter_subscription_event(&state.options, event) {
                 track_subscription_checkpoint(&mut state.last_seq_id, &filtered_event);
                 payload = callback_payload(&mut state.callback_mode, &filtered_event);
+                if let ChangeEvent::InitialDataBatch { batch_control, .. } = filtered_event {
+                    if batch_control.has_more && state.options.auto_fetch_batches.unwrap_or(false) {
+                        next_batch = Some((client_id.to_string(), state.last_seq_id));
+                    }
+                }
             }
 
             match event {
@@ -403,6 +457,7 @@ fn dispatch_subscription_server_message(
         payload,
         resolve_subscribe,
         reject_subscribe,
+        next_batch,
     })
 }
 
@@ -461,6 +516,7 @@ fn schedule_auto_reconnect(
     on_disconnect_cb: Rc<RefCell<Option<js_sys::Function>>>,
     on_error_cb: Rc<RefCell<Option<js_sys::Function>>>,
     on_receive_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    on_send_cb: Rc<RefCell<Option<js_sys::Function>>>,
     negotiated_ser: Rc<Cell<SerializationType>>,
 ) {
     let (delay, disable_compression) = {
@@ -524,6 +580,7 @@ fn schedule_auto_reconnect(
         let reconnect_on_disconnect = Rc::clone(&on_disconnect_cb);
         let reconnect_on_error = Rc::clone(&on_error_cb);
         let reconnect_on_receive = Rc::clone(&on_receive_cb);
+        let reconnect_on_send = Rc::clone(&on_send_cb);
         let reconnect_negotiated_ser = Rc::clone(&negotiated_ser);
         let next_url = url.clone();
         let next_auth = auth.clone();
@@ -538,6 +595,7 @@ fn schedule_auto_reconnect(
         let next_on_disconnect = Rc::clone(&on_disconnect_cb);
         let next_on_error = Rc::clone(&on_error_cb);
         let next_on_receive = Rc::clone(&on_receive_cb);
+        let next_on_send = Rc::clone(&on_send_cb);
         let next_negotiated_ser = Rc::clone(&negotiated_ser);
 
         wasm_bindgen_futures::spawn_local(async move {
@@ -563,6 +621,7 @@ fn schedule_auto_reconnect(
                         &ws,
                         Rc::clone(&reconnect_subscription_state),
                         Rc::clone(&reconnect_on_receive),
+                        Rc::clone(&reconnect_on_send),
                         Rc::clone(&reconnect_negotiated_ser),
                     );
                     if let Some(cb) = reconnect_on_connect.borrow().as_ref() {
@@ -585,12 +644,14 @@ fn schedule_auto_reconnect(
                         Rc::clone(&next_on_disconnect),
                         Rc::clone(&next_on_error),
                         Rc::clone(&next_on_receive),
+                        Rc::clone(&next_on_send),
                         Rc::clone(&next_negotiated_ser),
                     );
                     resubscribe_all(
                         Rc::clone(&reconnect_ws_ref),
                         Rc::clone(&reconnect_subscription_state),
                         reconnect_negotiated_ser.get(),
+                        Some(Rc::clone(&reconnect_on_send)),
                     )
                     .await;
                     reconnect::restart_ping_timer(
@@ -618,6 +679,7 @@ fn schedule_auto_reconnect(
                         next_on_disconnect,
                         next_on_error,
                         next_on_receive,
+                        next_on_send,
                         next_negotiated_ser,
                     );
                 },
@@ -695,8 +757,10 @@ fn install_runtime_message_handler(
     ws: &WebSocket,
     subscriptions: Rc<RefCell<HashMap<String, SubscriptionState>>>,
     on_receive_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    on_send_cb: Rc<RefCell<Option<js_sys::Function>>>,
     negotiated_ser: Rc<Cell<SerializationType>>,
 ) {
+    let ws_for_next_batch = ws.clone();
     let onmessage_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
         let event: Option<ServerMessage> = (|| {
             let data = e.data();
@@ -720,7 +784,15 @@ fn install_runtime_message_handler(
 
         if let Some(event) = event {
             if let Some(dispatch) = dispatch_subscription_server_message(&subscriptions, &event) {
-                dispatch.invoke();
+                if let Some((subscription_id, last_seq_id)) = dispatch.invoke() {
+                    let _ = send_next_batch_traced(
+                        &ws_for_next_batch,
+                        &subscription_id,
+                        last_seq_id,
+                        negotiated_ser.get(),
+                        &on_send_cb,
+                    );
+                }
             }
         }
     }) as Box<dyn FnMut(MessageEvent)>);
@@ -1242,9 +1314,11 @@ impl KalamClient {
         let auth_handled = Rc::new(RefCell::new(!requires_auth)); // Already handled if anonymous
         let auth_handled_clone = Rc::clone(&auth_handled);
         let on_receive_for_msg = Rc::clone(&self.on_receive_cb);
+        let on_send_for_msg = Rc::clone(&self.on_send_cb);
         let on_connect_for_msg = Rc::clone(&self.on_connect_cb);
         let on_error_for_msg = Rc::clone(&self.on_error_cb);
         let negotiated_ser_for_msg = Rc::clone(&self.negotiated_ser);
+        let ws_for_next_batch = ws.clone();
 
         let onmessage_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
             // Try to parse the message as a ServerMessage.
@@ -1331,7 +1405,15 @@ impl KalamClient {
             }
 
             if let Some(dispatch) = dispatch_subscription_server_message(&subscriptions, &event) {
-                dispatch.invoke();
+                if let Some((subscription_id, last_seq_id)) = dispatch.invoke() {
+                    let _ = send_next_batch_traced(
+                        &ws_for_next_batch,
+                        &subscription_id,
+                        last_seq_id,
+                        negotiated_ser_for_msg.get(),
+                        &on_send_for_msg,
+                    );
+                }
             }
         }) as Box<dyn FnMut(MessageEvent)>);
         ws.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
@@ -1357,6 +1439,7 @@ impl KalamClient {
                 Rc::clone(&self.ws),
                 Rc::clone(&self.subscription_state),
                 self.negotiated_ser.get(),
+                Some(Rc::clone(&self.on_send_cb)),
             )
             .await;
         }
@@ -1421,10 +1504,42 @@ impl KalamClient {
     pub fn send_ping(&self) -> Result<(), JsValue> {
         if let Some(ws) = self.ws.borrow().as_ref() {
             if ws.ready_state() == WebSocket::OPEN {
-                send_ws_message(ws, &ClientMessage::Ping, self.negotiated_ser.get())?;
+                send_ws_message_traced(
+                    ws,
+                    &ClientMessage::Ping,
+                    self.negotiated_ser.get(),
+                    &self.on_send_cb,
+                )?;
             }
         }
         Ok(())
+    }
+
+    /// Request the next initial-data batch for a subscription.
+    #[wasm_bindgen(js_name = requestNextBatch)]
+    pub fn request_next_batch(&self, subscription_id: String) -> Result<(), JsValue> {
+        let last_seq_id = self
+            .subscription_state
+            .borrow()
+            .get(&subscription_id)
+            .map(|state| state.last_seq_id)
+            .ok_or_else(|| JsValue::from_str("Unknown subscription id"))?;
+
+        let Some(ws) = self.ws.borrow().as_ref().cloned() else {
+            return Err(JsValue::from_str("WebSocket connection is unavailable"));
+        };
+
+        if ws.ready_state() != WebSocket::OPEN {
+            return Err(JsValue::from_str("WebSocket connection is not open"));
+        }
+
+        send_next_batch_traced(
+            &ws,
+            &subscription_id,
+            last_seq_id,
+            self.negotiated_ser.get(),
+            &self.on_send_cb,
+        )
     }
 
     /// Start the internal keepalive ping interval (idempotent).
@@ -1714,7 +1829,12 @@ impl KalamClient {
             let unsubscribe_msg = ClientMessage::Unsubscribe {
                 subscription_id: subscription_id.clone(),
             };
-            send_ws_message(ws, &unsubscribe_msg, self.negotiated_ser.get())?;
+            send_ws_message_traced(
+                ws,
+                &unsubscribe_msg,
+                self.negotiated_ser.get(),
+                &self.on_send_cb,
+            )?;
         }
 
         wasm_debug_log!(&format!("KalamClient: Unsubscribed from: {}", subscription_id));
@@ -2045,6 +2165,7 @@ impl KalamClient {
             Rc::clone(&self.on_disconnect_cb),
             Rc::clone(&self.on_error_cb),
             Rc::clone(&self.on_receive_cb),
+            Rc::clone(&self.on_send_cb),
             Rc::clone(&self.negotiated_ser),
         );
     }
@@ -2066,6 +2187,7 @@ fn install_auto_reconnect_listener(
     on_disconnect_cb: Rc<RefCell<Option<js_sys::Function>>>,
     on_error_cb: Rc<RefCell<Option<js_sys::Function>>>,
     on_receive_cb: Rc<RefCell<Option<js_sys::Function>>>,
+    on_send_cb: Rc<RefCell<Option<js_sys::Function>>>,
     negotiated_ser: Rc<Cell<SerializationType>>,
 ) {
     let source_ws = ws.clone();
@@ -2091,6 +2213,7 @@ fn install_auto_reconnect_listener(
             Rc::clone(&on_disconnect_cb),
             Rc::clone(&on_error_cb),
             Rc::clone(&on_receive_cb),
+            Rc::clone(&on_send_cb),
             Rc::clone(&negotiated_ser),
         );
     }) as Box<dyn FnMut(CloseEvent)>);

--- a/link/link-common/src/wasm/reconnect.rs
+++ b/link/link-common/src/wasm/reconnect.rs
@@ -199,6 +199,7 @@ pub(crate) async fn resubscribe_all(
     ws_ref: Rc<RefCell<Option<WebSocket>>>,
     subscription_state: Rc<RefCell<HashMap<String, SubscriptionState>>>,
     negotiated_ser: SerializationType,
+    on_send_cb: Option<Rc<RefCell<Option<js_sys::Function>>>>,
 ) {
     let states: Vec<(String, SubscriptionState)> = {
         let mut subs = subscription_state.borrow_mut();
@@ -239,6 +240,16 @@ pub(crate) async fn resubscribe_all(
                     "KalamClient: Failed to re-subscribe to {}: {:?}",
                     subscription_id, _e
                 ));
+            } else if let Some(on_send) = on_send_cb.as_ref() {
+                if let (Some(cb), Ok(json)) = (
+                    on_send.borrow().as_ref().cloned(),
+                    serde_json::to_string(&subscribe_msg),
+                ) {
+                    let _ = cb.call1(
+                        &wasm_bindgen::JsValue::NULL,
+                        &wasm_bindgen::JsValue::from_str(&json),
+                    );
+                }
             }
         }
     }

--- a/link/sdks/typescript/client/src/client.ts
+++ b/link/sdks/typescript/client/src/client.ts
@@ -39,6 +39,7 @@ import type {
   QueryResponse,
   SubscriptionCallback,
   SubscriptionErrorEvent,
+  SubscriptionHandle,
   SubscriptionOptions,
   Unsubscribe,
   UploadProgress,
@@ -1184,6 +1185,18 @@ export class KalamDBClient {
     callback: SubscriptionCallback,
     options?: SubscriptionOptions,
   ): Promise<Unsubscribe> {
+    const handle = await this.subscribeWithSqlHandle(sql, callback, options);
+    return handle.unsubscribe;
+  }
+
+  /**
+   * Subscribe to a SQL query and receive a handle for explicit batch control.
+   */
+  async subscribeWithSqlHandle(
+    sql: string,
+    callback: SubscriptionCallback,
+    options?: SubscriptionOptions,
+  ): Promise<SubscriptionHandle> {
     this.log(LogLevel.Debug, 'subscription', `Subscribing to: ${sql.substring(0, 120)}`);
     const optionsJson = this.stringifyOptions(normalizeSubscriptionOptions(options));
     const subscriptionId = await this.startTrackedSubscription(
@@ -1195,9 +1208,28 @@ export class KalamDBClient {
       ),
     );
 
-    return async () => {
-      await this.unsubscribe(subscriptionId);
+    return {
+      id: subscriptionId,
+      unsubscribe: async () => {
+        await this.unsubscribe(subscriptionId);
+      },
+      requestNextBatch: async () => {
+        await this.requestNextBatch(subscriptionId);
+      },
     };
+  }
+
+  /** Request the next initial-data batch for an active subscription. */
+  async requestNextBatch(subscriptionId: string): Promise<void> {
+    await this.ensureConnected();
+    const wasmClient = this.wasmClient;
+    if (!wasmClient) {
+      throw new Error('WASM client not initialized');
+    }
+
+    await this.serializeWasmCall(() => Promise.resolve(
+      (wasmClient as unknown as { requestNextBatch: (id: string) => void }).requestNextBatch(subscriptionId),
+    ));
   }
 
   /**

--- a/link/sdks/typescript/client/src/helpers/subscription_helpers.ts
+++ b/link/sdks/typescript/client/src/helpers/subscription_helpers.ts
@@ -10,12 +10,12 @@ import type {
 
 export function normalizeSubscriptionOptions(
   options?: SubscriptionOptions,
-): { batch_size?: number; last_rows?: number; from?: string } | undefined {
+): { batch_size?: number; last_rows?: number; from?: string; auto_fetch_batches?: boolean } | undefined {
   if (!options) {
     return undefined;
   }
 
-  const normalized: { batch_size?: number; last_rows?: number; from?: string } = {};
+  const normalized: { batch_size?: number; last_rows?: number; from?: string; auto_fetch_batches?: boolean } = {};
 
   if (options.batch_size !== undefined) {
     normalized.batch_size = options.batch_size;
@@ -27,6 +27,11 @@ export function normalizeSubscriptionOptions(
 
   if (options.from !== undefined) {
     normalized.from = options.from instanceof SeqId ? options.from.toString() : SeqId.from(options.from).toString();
+  }
+
+  const autoFetchBatches = options.auto_fetch_batches ?? options.autoFetchBatches;
+  if (autoFetchBatches !== undefined) {
+    normalized.auto_fetch_batches = autoFetchBatches;
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;

--- a/link/sdks/typescript/client/src/index.ts
+++ b/link/sdks/typescript/client/src/index.ts
@@ -87,6 +87,7 @@ export type {
   ServerMessage,
   SubscriptionCallback,
   SubscriptionErrorEvent,
+  SubscriptionHandle,
   SubscriptionInfo,
   SubscriptionOptions,
   TimestampFormat,

--- a/link/sdks/typescript/client/src/types.ts
+++ b/link/sdks/typescript/client/src/types.ts
@@ -203,6 +203,10 @@ export interface SubscriptionOptions {
   last_rows?: number;
   /** Resume from a specific sequence ID. */
   from?: WireSeqId;
+  /** Request every initial-data batch automatically when the server has more rows. */
+  auto_fetch_batches?: boolean;
+  /** Camel-case alias accepted by the WASM layer. Prefer auto_fetch_batches. */
+  autoFetchBatches?: boolean;
 }
 
 /* ================================================================== */
@@ -370,6 +374,18 @@ export interface LiveRowsOptions<T> {
  * Function to unsubscribe from a subscription (Firebase/Supabase style)
  */
 export type Unsubscribe = () => Promise<void>;
+
+/**
+ * Handle for a live subscription with explicit batch control.
+ */
+export interface SubscriptionHandle {
+  /** Server/client subscription id used in WebSocket messages. */
+  id: string;
+  /** Unsubscribe from this subscription. */
+  unsubscribe: Unsubscribe;
+  /** Fetch the next initial-data batch for this subscription. */
+  requestNextBatch: () => Promise<void>;
+}
 
 /* ================================================================== */
 /*  Connection Lifecycle Event Handlers                               */

--- a/link/sdks/typescript/client/tests/normalize.test.mjs
+++ b/link/sdks/typescript/client/tests/normalize.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { normalizeQueryResponse, sortColumns, SYSTEM_TABLES_ORDER } from '../dist/src/helpers/query_helpers.js';
+import { normalizeSubscriptionOptions } from '../dist/src/helpers/subscription_helpers.js';
 
 // Helper: build a minimal QueryResponse using the current schema format
 function makeResp(columnNames, rows) {
@@ -74,6 +75,18 @@ function getColumns(resp) {
   // unknowns at the end (relative order preserved: x before y)
   const tail = sorted.slice(-2);
   assert.deepEqual(tail, ['x', 'y']);
+}
+
+// Subscription options include SDK-only batch control and accept camel-case alias.
+{
+  assert.deepEqual(
+    normalizeSubscriptionOptions({ batch_size: 5, auto_fetch_batches: false }),
+    { batch_size: 5, auto_fetch_batches: false },
+  );
+  assert.deepEqual(
+    normalizeSubscriptionOptions({ autoFetchBatches: true }),
+    { auto_fetch_batches: true },
+  );
 }
 
 console.log('normalize.test.mjs passed');

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="%BASE_URL%runtime-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/ui/src/components/sql-studio-v2/input-form/QueryTabStrip.tsx
+++ b/ui/src/components/sql-studio-v2/input-form/QueryTabStrip.tsx
@@ -69,22 +69,46 @@ export function QueryTabStrip({
         {tabs.map((tab) => {
           const isActive = tab.id === activeTabId;
           const isFlashing = flashingTabIds[tab.id] === true;
+          const isLive = tab.isLive;
+          const isLiveConnecting = isLive && tab.liveStatus === "connecting";
+          const isLiveConnected = isLive && tab.liveStatus === "connected";
+          const isLiveErrored = isLive && tab.liveStatus === "error";
           return (
             <button
               key={tab.id}
               type="button"
               onClick={() => onTabSelect(tab.id)}
               className={cn(
-                "group flex h-11 min-w-[168px] max-w-[280px] items-center gap-2 border-r border-border px-3 text-sm transition-colors",
+                "group relative flex h-11 min-w-[168px] max-w-[280px] items-center gap-2 overflow-hidden border-r border-border px-3 text-sm transition-colors",
                 isActive
                   ? "border-t-2 border-t-sky-500 bg-background text-foreground"
                   : "text-muted-foreground hover:bg-muted :bg-accent",
+                isLive && "backdrop-blur-sm",
+                isLiveConnected && (isActive
+                  ? "bg-sky-500/12 shadow-[0_0_24px_rgba(14,165,233,0.16)]"
+                  : "bg-sky-500/8 shadow-[0_0_18px_rgba(14,165,233,0.12)]"),
+                isLiveConnecting && "bg-sky-500/10 shadow-[0_0_18px_rgba(14,165,233,0.12)] animate-pulse",
+                isLiveErrored && "bg-red-500/8 shadow-[0_0_18px_rgba(239,68,68,0.12)]",
                 tab.unreadChangeCount > 0 && !isActive && "text-foreground",
                 isFlashing && !isActive && "bg-amber-500/10 ring-inset ring-1 ring-amber-500/30 animate-[pulse_0.8s_ease-out_1]",
               )}
             >
               <FileCode2 className={cn("h-3.5 w-3.5 shrink-0", isActive ? "text-primary" : "text-muted-foreground")} />
-              <span className="min-w-0 flex-1 truncate text-left">{tab.title}</span>
+              <span className="min-w-0 flex-1 truncate text-left">
+                {isLive && (
+                  <span
+                    aria-label={`Live query ${tab.liveStatus}`}
+                    className={cn(
+                      "mr-2 inline-flex h-2.5 w-2.5 align-middle rounded-full",
+                      isLiveErrored && "bg-red-500 shadow-[0_0_10px_rgba(239,68,68,0.32)]",
+                      isLiveConnecting && "bg-sky-400/90 ring-2 ring-sky-500/20",
+                      isLiveConnected && "bg-sky-500 shadow-[0_0_12px_rgba(14,165,233,0.36)] animate-pulse",
+                      !isLiveErrored && !isLiveConnecting && !isLiveConnected && "bg-sky-500/80",
+                    )}
+                  />
+                )}
+                <span className="align-middle">{tab.title}</span>
+              </span>
               <span className="ml-auto flex shrink-0 items-center gap-1.5">
                 {tab.unreadChangeCount > 0 && !isActive && (
                   <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-amber-950">

--- a/ui/src/components/sql-studio-v2/input-form/StudioEditorPanel.tsx
+++ b/ui/src/components/sql-studio-v2/input-form/StudioEditorPanel.tsx
@@ -530,6 +530,21 @@ export function StudioEditorPanel({
               className="h-7 w-28 border-border bg-background text-xs"
             />
           </div>
+          <label className="flex items-center gap-1.5 text-xs text-muted-foreground" htmlFor="opt-auto-fetch-batches">
+            <input
+              id="opt-auto-fetch-batches"
+              type="checkbox"
+              checked={subscriptionOptions?.auto_fetch_batches ?? false}
+              onChange={(event) => {
+                onSubscriptionOptionsChange({
+                  ...subscriptionOptions,
+                  auto_fetch_batches: event.target.checked,
+                });
+              }}
+              className="h-3.5 w-3.5 rounded border-border accent-primary"
+            />
+            auto fetch batches
+          </label>
           <Button
             variant="ghost"
             size="sm"

--- a/ui/src/components/sql-studio-v2/preview/StudioResultsGrid.tsx
+++ b/ui/src/components/sql-studio-v2/preview/StudioResultsGrid.tsx
@@ -44,11 +44,14 @@ interface StudioResultsGridProps {
   result: QueryResultData | null;
   isRunning: boolean;
   isLiveMode: boolean;
+  liveBatch?: { hasMore: boolean; batchNum?: number; status?: string };
+  liveAutoFetchBatches?: boolean;
   activeSql: string;
   selectedTable: StudioTable | null;
   currentUsername: string;
   resultView: SqlStudioResultView;
   onResultViewChange: (view: SqlStudioResultView) => void;
+  onFetchNextBatch?: () => void;
   onRefreshAfterCommit: () => void;
 }
 
@@ -145,11 +148,14 @@ export function StudioResultsGrid({
   result,
   isRunning,
   isLiveMode,
+  liveBatch,
+  liveAutoFetchBatches = false,
   activeSql,
   selectedTable,
   currentUsername,
   resultView,
   onResultViewChange,
+  onFetchNextBatch,
   onRefreshAfterCommit,
 }: StudioResultsGridProps) {
   const [sortState, setSortState] = useState<SortState>(null);
@@ -572,6 +578,13 @@ export function StudioResultsGrid({
   const deleteCount = deletions.size;
   const logCount = result?.logs.length ?? 0;
   const showResultsTable = hasTabularResults && resultView === "results";
+  const canFetchNextLiveBatch = Boolean(
+    isLiveMode
+    && resultView === "results"
+    && liveBatch?.hasMore
+    && !liveAutoFetchBatches
+    && onFetchNextBatch,
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
@@ -621,6 +634,17 @@ export function StudioResultsGrid({
               <span className="rounded bg-border px-1.5 py-0.5 text-[10px] text-foreground">
                 {sortState.columnName} ({sortState.direction})
               </span>
+            )}
+            {canFetchNextLiveBatch && (
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-7 gap-1.5"
+                onClick={onFetchNextBatch}
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+                Fetch next batch
+              </Button>
             )}
             <Button
               size="sm"
@@ -720,14 +744,15 @@ export function StudioResultsGrid({
               <table className="min-w-max border-collapse">
               <thead className="sticky top-0 z-10">
                 <tr>
-                  <th className="w-10 border-r border-border bg-background px-2 py-2 text-left">
-                    {isLiveMode ? (
-                      <div className="flex items-center justify-center">
-                        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          Change
-                        </span>
-                      </div>
-                    ) : canMutateRows ? (
+                  {isLiveMode ? (
+                    <th className="w-[148px] border-r border-border bg-muted/40 px-2 py-2 text-left">
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        Live
+                      </span>
+                    </th>
+                  ) : (
+                    <th className="w-10 border-r border-border bg-background px-2 py-2 text-left">
+                      {canMutateRows ? (
                       <div className="flex items-center justify-center">
                         <input
                           type="checkbox"
@@ -746,10 +771,11 @@ export function StudioResultsGrid({
                           className="h-3.5 w-3.5 rounded border-border bg-transparent disabled:opacity-40"
                         />
                       </div>
-                    ) : (
-                      <div className="h-3.5 w-3.5" />
-                    )}
-                  </th>
+                      ) : (
+                        <div className="h-3.5 w-3.5" />
+                      )}
+                    </th>
+                  )}
                   {schema.map((field) => {
                     const isSorted = sortState?.columnName === field.name;
                     return (
@@ -808,6 +834,12 @@ export function StudioResultsGrid({
                   const liveChangedAt = isLiveMode
                     ? (row[LIVE_META.CHANGED_AT] as string | undefined)
                     : undefined;
+                  const liveBatchNum = isLiveMode
+                    ? (row[LIVE_META.BATCH_NUM] as string | number | undefined)
+                    : undefined;
+                  const liveChangeLabel = liveChangeType === "initial" && liveBatchNum
+                    ? `initial #${liveBatchNum}`
+                    : liveChangeType;
                   const liveChangedCols = isLiveMode && liveChangeType === "update"
                     ? new Set((row[LIVE_META.CHANGED_COLS] as string | undefined)?.split(",").filter(Boolean) ?? [])
                     : null;
@@ -835,31 +867,32 @@ export function StudioResultsGrid({
                         isLiveUpdate && "bg-amber-500/5",
                       )}
                     >
-                      <td className="border-r border-border px-2 py-1">
-                        {isLiveMode ? (
-                          <div className="flex flex-col items-center justify-center gap-0.5 min-w-[60px]">
-                            {liveChangeType && (
-                              <>
-                                <span
-                                  className={cn(
-                                    "rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide",
-                                    liveChangeType === "initial" && "bg-background0/20 text-foreground ",
-                                    liveChangeType === "insert" && "bg-sky-500/20 text-sky-700 ",
-                                    liveChangeType === "update" && "bg-amber-500/20 text-amber-700 ",
-                                    liveChangeType === "delete" && "bg-red-500/20 text-red-700 ",
-                                  )}
-                                >
-                                  {liveChangeType}
-                                </span>
-                                {liveChangedAt && (
-                                  <span className="text-[9px] text-muted-foreground">
-                                    {new Date(liveChangedAt).toLocaleTimeString()}
-                                  </span>
+                      {isLiveMode ? (
+                        <td className="border-r border-border bg-muted/25 px-2 py-1 align-middle">
+                          <div className="flex min-h-[32px] min-w-[132px] items-center gap-2 whitespace-nowrap">
+                            {liveChangedAt && (
+                              <span className="shrink-0 text-[9px] text-muted-foreground">
+                                {new Date(liveChangedAt).toLocaleTimeString()}
+                              </span>
+                            )}
+                            {liveChangeLabel && (
+                              <span
+                                className={cn(
+                                  "inline-flex w-fit items-center rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide",
+                                  liveChangeType === "initial" && "bg-sky-500/12 text-sky-700",
+                                  liveChangeType === "insert" && "bg-sky-500/20 text-sky-700",
+                                  liveChangeType === "update" && "bg-amber-500/20 text-amber-700",
+                                  liveChangeType === "delete" && "bg-red-500/20 text-red-700",
                                 )}
-                              </>
+                              >
+                                {liveChangeLabel}
+                              </span>
                             )}
                           </div>
-                        ) : canMutateRows ? (
+                        </td>
+                      ) : (
+                        <td className="border-r border-border px-2 py-1">
+                          {canMutateRows ? (
                           <div className="flex items-center justify-center">
                             <input
                               type="checkbox"
@@ -878,10 +911,11 @@ export function StudioResultsGrid({
                               className="h-3.5 w-3.5 rounded border-border bg-transparent disabled:opacity-40"
                             />
                           </div>
-                        ) : (
-                          <div className="h-3.5 w-3.5" />
-                        )}
-                      </td>
+                          ) : (
+                            <div className="h-3.5 w-3.5" />
+                          )}
+                        </td>
+                      )}
 
                       {schema.map((field) => {
                         const value = getCellEditedValue(rowIndex, field.name) ?? row[field.name];

--- a/ui/src/components/sql-studio-v2/shared/types.ts
+++ b/ui/src/components/sql-studio-v2/shared/types.ts
@@ -2,6 +2,7 @@ export interface LiveSubscriptionOptions {
   batch_size?: number;
   last_rows?: number;
   from?: string;
+  auto_fetch_batches?: boolean;
 }
 
 export interface StudioColumn {

--- a/ui/src/components/sql-studio-v2/shared/workspaceState.ts
+++ b/ui/src/components/sql-studio-v2/shared/workspaceState.ts
@@ -6,6 +6,7 @@ interface PersistedSubscriptionOptions {
   batch_size?: number;
   last_rows?: number;
   from?: string;
+  auto_fetch_batches?: boolean;
 }
 
 export interface SqlStudioPersistedQueryTab {
@@ -89,6 +90,9 @@ function normalizeSubscriptionOptions(value: unknown): PersistedSubscriptionOpti
   }
   if (typeof record.from === "number" || typeof record.from === "string") {
     result.from = String(record.from);
+  }
+  if (typeof record.auto_fetch_batches === "boolean") {
+    result.auto_fetch_batches = record.auto_fetch_batches;
   }
   return Object.keys(result).length > 0 ? result : undefined;
 }

--- a/ui/src/features/sql-studio/state/sqlStudioWorkspaceSlice.ts
+++ b/ui/src/features/sql-studio/state/sqlStudioWorkspaceSlice.ts
@@ -39,6 +39,8 @@ const LIVE_META = {
   CHANGED_AT: "_live_changed_at",
   /** Comma-separated list of columns that changed (for update highlighting) */
   CHANGED_COLS: "_live_changed_cols",
+  /** Initial snapshot batch number, 1-based for display */
+  BATCH_NUM: "_live_batch_num",
 } as const;
 
 /** How long (ms) a change highlight persists before fading. */
@@ -87,6 +89,7 @@ function mergeLiveRowsIntoResult(
   incomingRows: Record<string, unknown>[],
   changeType: string,
   incomingSchema?: QueryResultSchemaField[],
+  batchNum?: number,
 ): QueryResultData {
   const now = new Date().toISOString();
   const existingRows = previous?.rows ?? [];
@@ -129,6 +132,7 @@ function mergeLiveRowsIntoResult(
           [LIVE_META.CHANGE_TYPE]: "delete",
           [LIVE_META.CHANGED_AT]: now,
           [LIVE_META.CHANGED_COLS]: "",
+          [LIVE_META.BATCH_NUM]: "",
         };
       } else {
         // Row not in table yet — add it as deleted
@@ -137,6 +141,7 @@ function mergeLiveRowsIntoResult(
           [LIVE_META.CHANGE_TYPE]: "delete",
           [LIVE_META.CHANGED_AT]: now,
           [LIVE_META.CHANGED_COLS]: "",
+          [LIVE_META.BATCH_NUM]: "",
         });
       }
     } else if (changeType === "update") {
@@ -153,6 +158,7 @@ function mergeLiveRowsIntoResult(
           [LIVE_META.CHANGE_TYPE]: "update",
           [LIVE_META.CHANGED_AT]: now,
           [LIVE_META.CHANGED_COLS]: changedCols.join(","),
+          [LIVE_META.BATCH_NUM]: "",
         };
       } else {
         // PK not found — treat as insert
@@ -161,6 +167,7 @@ function mergeLiveRowsIntoResult(
           [LIVE_META.CHANGE_TYPE]: "update",
           [LIVE_META.CHANGED_AT]: now,
           [LIVE_META.CHANGED_COLS]: "",
+          [LIVE_META.BATCH_NUM]: "",
         });
       }
     } else if (changeType === "insert") {
@@ -171,6 +178,7 @@ function mergeLiveRowsIntoResult(
           [LIVE_META.CHANGE_TYPE]: "insert",
           [LIVE_META.CHANGED_AT]: now,
           [LIVE_META.CHANGED_COLS]: "",
+          [LIVE_META.BATCH_NUM]: "",
         };
       } else {
         rows.push({
@@ -178,6 +186,7 @@ function mergeLiveRowsIntoResult(
           [LIVE_META.CHANGE_TYPE]: "insert",
           [LIVE_META.CHANGED_AT]: now,
           [LIVE_META.CHANGED_COLS]: "",
+          [LIVE_META.BATCH_NUM]: "",
         });
         if (key !== null) pkIndex.set(key, rows.length - 1);
       }
@@ -186,8 +195,9 @@ function mergeLiveRowsIntoResult(
       rows.push({
         ...incoming,
         [LIVE_META.CHANGE_TYPE]: changeType,
-        [LIVE_META.CHANGED_AT]: "",
+        [LIVE_META.CHANGED_AT]: now,
         [LIVE_META.CHANGED_COLS]: "",
+        [LIVE_META.BATCH_NUM]: changeType === "initial" ? batchNum ?? "" : "",
       });
       if (key !== null) pkIndex.set(key, rows.length - 1);
     }
@@ -222,7 +232,7 @@ function buildFallbackSchema(
 function ensureLiveMetaCols(
   schema: QueryResultSchemaField[],
 ): QueryResultSchemaField[] {
-  const metaCols = [LIVE_META.CHANGE_TYPE, LIVE_META.CHANGED_AT, LIVE_META.CHANGED_COLS];
+  const metaCols = [LIVE_META.CHANGE_TYPE, LIVE_META.CHANGED_AT, LIVE_META.CHANGED_COLS, LIVE_META.BATCH_NUM];
   const missing = metaCols.filter((c) => !schema.some((f) => f.name === c));
   if (missing.length === 0) return schema;
 
@@ -385,6 +395,7 @@ const sqlStudioWorkspaceSlice = createSlice({
         rows: Record<string, unknown>[];
         changeType: string;
         schema?: QueryResultSchemaField[];
+        batchNum?: number;
       }>,
     ) {
       const {
@@ -392,12 +403,14 @@ const sqlStudioWorkspaceSlice = createSlice({
         rows,
         changeType,
         schema,
+        batchNum,
       } = action.payload;
       state.tabResults[tabId] = mergeLiveRowsIntoResult(
         state.tabResults[tabId] ?? null,
         rows,
         changeType,
         schema,
+        batchNum,
       );
     },
     appendWorkspaceResultLog(

--- a/ui/src/lib/kalam-client.ts
+++ b/ui/src/lib/kalam-client.ts
@@ -27,6 +27,7 @@ import {
   type QueryResponse,
   type RowData,
   type ServerMessage,
+  type SubscriptionHandle,
   type SubscriptionOptions,
   type Unsubscribe,
 } from '@kalamdb/client';
@@ -424,8 +425,10 @@ function parseOptionsFromSql(sql: string): { sql: string; options: SubscriptionO
           options.last_rows = parseInt(value, 10);
         } else if (keyLower === 'batch_size') {
           options.batch_size = parseInt(value, 10);
-        } else if (keyLower === 'from') {
+        } else if (keyLower === 'from' || keyLower === 'from_seq_id') {
           options.from = value;
+        } else if (keyLower === 'auto_fetch_batches' || keyLower === 'auto_fetch_next_batch') {
+          options.auto_fetch_batches = value.toLowerCase() === 'true' || value === '1';
         }
       }
     }
@@ -459,6 +462,7 @@ function normalizeSubscriptionTarget(
       last_rows: parsedOptions.last_rows ?? options?.last_rows,
       batch_size: parsedOptions.batch_size ?? options?.batch_size,
       from: parsedOptions.from ?? options?.from,
+      auto_fetch_batches: parsedOptions.auto_fetch_batches ?? options?.auto_fetch_batches,
     },
     isSqlQuery: isSqlQueryTarget(cleanSql),
   };
@@ -478,22 +482,36 @@ export async function subscribe(
   callback: (event: ServerMessage) => void,
   options?: SubscriptionOptions
 ): Promise<Unsubscribe> {
+  const handle = await subscribeWithHandle(tableOrQuery, callback, options);
+  return handle.unsubscribe;
+}
+
+export async function subscribeWithHandle(
+  tableOrQuery: string,
+  callback: (event: ServerMessage) => void,
+  options?: SubscriptionOptions,
+): Promise<SubscriptionHandle> {
   const liveClient = await ensureSubscriptionClient();
   const { cleanSql, subscribeOptions, isSqlQuery } = normalizeSubscriptionTarget(tableOrQuery, options);
   
   debugLog('[kalam-client] Subscribing to:', cleanSql, 'with options:', subscribeOptions);
 
   try {
-    const unsubscribe = isSqlQuery
-      ? await liveClient.subscribeWithSql(cleanSql, callback, subscribeOptions)
-      : await liveClient.subscribe(cleanSql, callback, subscribeOptions);
+    const handle = isSqlQuery
+      ? await liveClient.subscribeWithSqlHandle(cleanSql, callback, subscribeOptions)
+      : await liveClient.subscribeWithSqlHandle(`SELECT * FROM ${cleanSql}`, callback, subscribeOptions);
 
     debugLog('[kalam-client] Subscription registered successfully');
-    return unsubscribe;
+    return handle;
   } catch (err) {
     console.error('[kalam-client] Subscription setup failed:', err);
     throw err;
   }
+}
+
+export async function requestNextBatch(subscriptionId: string): Promise<void> {
+  const liveClient = await ensureSubscriptionClient();
+  await liveClient.requestNextBatch(subscriptionId);
 }
 
 /**

--- a/ui/src/pages/SqlStudio.test.tsx
+++ b/ui/src/pages/SqlStudio.test.tsx
@@ -23,6 +23,7 @@ const mockSetClientErrorListener = vi.fn();
 const mockSetClientReceiveListener = vi.fn();
 const mockSetClientSendListener = vi.fn();
 const mockUnsubscribe = vi.fn();
+const mockRequestNextBatch = vi.fn();
 const mockRemoteUnsubscribe = vi.fn();
 const mockSaveSyncedSqlStudioWorkspaceState = vi.fn();
 const mockLoadSyncedSqlStudioWorkspaceState = vi.fn();
@@ -54,6 +55,7 @@ vi.mock("@/services/sqlStudioService", async () => {
 
 vi.mock("@/lib/kalam-client", () => ({
   subscribe: (...args: unknown[]) => mockSubscribe(...args),
+  subscribeWithHandle: (...args: unknown[]) => mockSubscribe(...args),
   setClientDisconnectListener: (...args: unknown[]) => mockSetClientDisconnectListener(...args),
   setClientErrorListener: (...args: unknown[]) => mockSetClientErrorListener(...args),
   setClientLogListener: (...args: unknown[]) => mockSetClientLogListener(...args),
@@ -280,6 +282,7 @@ describe("SqlStudio page", () => {
     mockSetClientReceiveListener.mockReset();
     mockSetClientSendListener.mockReset();
     mockUnsubscribe.mockReset();
+    mockRequestNextBatch.mockReset();
     mockRemoteUnsubscribe.mockReset();
     mockLoadSyncedSqlStudioWorkspaceState.mockReset();
     mockSaveSyncedSqlStudioWorkspaceState.mockReset();
@@ -326,7 +329,11 @@ describe("SqlStudio page", () => {
 
     mockSubscribe.mockImplementation(async (_sql: string, callback: (message: Record<string, unknown>) => void) => {
       liveCallback = callback;
-      return mockUnsubscribe;
+      return {
+        id: "sub-test",
+        unsubscribe: mockUnsubscribe,
+        requestNextBatch: mockRequestNextBatch,
+      };
     });
     mockLoadSyncedSqlStudioWorkspaceState.mockResolvedValue(null);
     mockSaveSyncedSqlStudioWorkspaceState.mockResolvedValue(undefined);
@@ -626,7 +633,7 @@ describe("SqlStudio page", () => {
   });
 
   it("starts a live subscription from the SQL Studio page and renders incoming change rows", async () => {
-    await renderSqlStudio();
+    const { store } = await renderSqlStudio();
 
     fireEvent.change(getSqlEditor(), {
       target: { value: "SELECT id, name FROM default.events" },
@@ -646,6 +653,9 @@ describe("SqlStudio page", () => {
     await act(async () => {
       liveCallback?.({
         type: "subscription_ack",
+        subscription_id: "sub-test",
+        total_rows: 0,
+        batch_control: { batch_num: 0, has_more: false, status: "ready" },
         schema: [
           { name: "id", data_type: "BigInt", index: 0, flags: ["pk"] },
           { name: "name", data_type: "Text", index: 1 },
@@ -658,9 +668,16 @@ describe("SqlStudio page", () => {
       });
     });
 
+    const activeTabTitle = store.getState().sqlStudioWorkspace.tabs[0]?.title;
+
     expect(await screen.findByText("stream row")).toBeTruthy();
     expect(screen.getByText("insert")).toBeTruthy();
     expect(screen.getByRole("button", { name: /stop/i })).toBeTruthy();
+    if (activeTabTitle) {
+      const liveTabButton = screen.getByRole("button", { name: new RegExp(activeTabTitle, "i") });
+      expect(within(liveTabButton).getByLabelText("Live query connected")).toBeTruthy();
+      expect(within(liveTabButton).getByText(activeTabTitle)).toBeTruthy();
+    }
   });
 
   it("removes the browser-added limit when live mode is enabled", async () => {
@@ -723,9 +740,9 @@ describe("SqlStudio page", () => {
   });
 
   it("shows connecting state and lets the user cancel a stalled live subscription", async () => {
-    let resolveSubscribe: ((value: () => Promise<void>) => void) | null = null;
+    let resolveSubscribe: ((value: { id: string; unsubscribe: () => Promise<void>; requestNextBatch: () => Promise<void> }) => void) | null = null;
     mockSubscribe.mockImplementationOnce(() => new Promise((resolve) => {
-      resolveSubscribe = resolve as (value: () => Promise<void>) => void;
+      resolveSubscribe = resolve as (value: { id: string; unsubscribe: () => Promise<void>; requestNextBatch: () => Promise<void> }) => void;
     }));
 
     await renderSqlStudio();
@@ -746,7 +763,7 @@ describe("SqlStudio page", () => {
     });
 
     await act(async () => {
-      resolveSubscribe?.(mockUnsubscribe);
+      resolveSubscribe?.({ id: "sub-test", unsubscribe: mockUnsubscribe, requestNextBatch: mockRequestNextBatch });
     });
 
     expect(mockUnsubscribe).toHaveBeenCalled();
@@ -769,6 +786,9 @@ describe("SqlStudio page", () => {
     await act(async () => {
       liveCallback?.({
         type: "subscription_ack",
+        subscription_id: "sub-test",
+        total_rows: 0,
+        batch_control: { batch_num: 0, has_more: true, status: "loading" },
         schema: [
           { name: "id", data_type: "BigInt", index: 0, flags: ["pk"] },
           { name: "name", data_type: "Text", index: 1 },
@@ -777,6 +797,8 @@ describe("SqlStudio page", () => {
       });
       liveCallback?.({
         type: "initial_data_batch",
+        subscription_id: "sub-test",
+        batch_control: { batch_num: 0, has_more: true, status: "loading" },
         rows: [
           { id: 1, name: "oldest", _seq: "10" },
           { id: 2, name: "newest", _seq: "30" },
@@ -791,6 +813,15 @@ describe("SqlStudio page", () => {
 
     expect(newestCell.compareDocumentPosition(middleCell) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(middleCell.compareDocumentPosition(oldestCell) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByRole("columnheader", { name: "Live" })).not.toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "Time" })).toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "Change" })).toBeNull();
+    expect(screen.getAllByText("initial #1")).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole("button", { name: /fetch next batch/i }));
+    await waitFor(() => {
+      expect(mockRequestNextBatch).toHaveBeenCalled();
+    });
   });
 
   it("appends raw websocket send and receive traces to the log", async () => {
@@ -809,8 +840,8 @@ describe("SqlStudio page", () => {
     });
 
     await act(async () => {
-      clientSendCallback?.('{"type":"subscribe","sql":"SELECT id, name FROM default.events"}');
-      clientReceiveCallback?.('{"type":"subscription_ack","subscription_id":"sub-1"}');
+      clientSendCallback?.('{"type":"subscribe","subscription":{"id":"sub-test","sql":"SELECT id, name FROM default.events"}}');
+      clientReceiveCallback?.('{"type":"subscription_ack","subscription_id":"sub-test"}');
     });
 
     await waitFor(() => {
@@ -841,6 +872,9 @@ describe("SqlStudio page", () => {
     await act(async () => {
       liveCallback?.({
         type: "subscription_ack",
+        subscription_id: "sub-test",
+        total_rows: 0,
+        batch_control: { batch_num: 0, has_more: false, status: "ready" },
         schema: [
           { name: "id", data_type: "BigInt", index: 0, flags: ["pk"] },
           { name: "name", data_type: "Text", index: 1 },
@@ -877,6 +911,9 @@ describe("SqlStudio page", () => {
     await act(async () => {
       liveCallback?.({
         type: "subscription_ack",
+        subscription_id: "sub-test",
+        total_rows: 0,
+        batch_control: { batch_num: 0, has_more: false, status: "ready" },
         schema: [
           { name: "id", data_type: "BigInt", index: 0, flags: ["pk"] },
           { name: "name", data_type: "Text", index: 1 },

--- a/ui/src/pages/SqlStudio.tsx
+++ b/ui/src/pages/SqlStudio.tsx
@@ -22,7 +22,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { useAuth } from "@/lib/auth";
 import {
-  subscribe,
+  subscribeWithHandle,
   setClientLogListener,
   setClientSendListener,
   setClientReceiveListener,
@@ -110,6 +110,13 @@ import {
 
 const WORKSPACE_PERSIST_DEBOUNCE_MS = 750;
 
+interface LiveBatchState {
+  hasMore: boolean;
+  batchNum?: number;
+  status?: string;
+  subscriptionId?: string;
+}
+
 function normalizeLiveRows(rows: unknown[]): Record<string, unknown>[] {
   return rows.map((row) => {
     if (row instanceof Map) {
@@ -134,10 +141,34 @@ function extractWsMessageType(raw: string): string {
 function extractWsSubscriptionId(raw: string): string | null {
   try {
     const parsed = JSON.parse(raw);
-    return typeof parsed?.subscription_id === "string" ? parsed.subscription_id : null;
+    if (typeof parsed?.subscription_id === "string") {
+      return parsed.subscription_id;
+    }
+    return typeof parsed?.subscription?.id === "string" ? parsed.subscription.id : null;
   } catch {
     return null;
   }
+}
+
+function extractWsSubscriptionSql(raw: string): string | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.subscription?.sql === "string") {
+      return parsed.subscription.sql;
+    }
+    return typeof parsed?.sql === "string" ? parsed.sql : null;
+  } catch {
+    return null;
+  }
+}
+
+function stripTrailingOptionsClause(sql: string): string {
+  const cleanSql = sql.replace(/\s+OPTIONS\s*\([^)]+\)\s*;?\s*$/i, "").trim();
+  return cleanSql.endsWith(";") ? cleanSql.slice(0, -1).trim() : cleanSql;
+}
+
+function displayBatchNum(batchNum: number | undefined): number | undefined {
+  return Number.isFinite(batchNum) ? Number(batchNum) + 1 : undefined;
 }
 
 function isWsErrorFrame(messageType: string): boolean {
@@ -237,7 +268,9 @@ export default function SqlStudio() {
   const { openSqlPreview } = useSqlPreview();
   const [isUiHydrated, setIsUiHydrated] = useState(false);
   const [isRemoteWorkspaceHydrated, setIsRemoteWorkspaceHydrated] = useState(false);
+  const [liveBatchByTab, setLiveBatchByTab] = useState<Record<string, LiveBatchState>>({});
   const liveUnsubscribeRef = useRef<Record<string, Unsubscribe>>({});
+  const liveRequestNextBatchRef = useRef<Record<string, () => Promise<void>>>({});
   const liveGenRef = useRef<Record<string, number>>({});
   const liveSubscriptionIdRef = useRef<Record<string, string>>({});
   const consumedPrefillKeyRef = useRef<string | null>(null);
@@ -255,6 +288,7 @@ export default function SqlStudio() {
     [tabs, activeTabId],
   );
   const activeResult = activeTab ? (tabResults[activeTab.id] ?? null) : null;
+  const activeLiveBatch = activeTab ? liveBatchByTab[activeTab.id] : undefined;
   const selectedTable = useMemo(() => {
     if (!selectedTableKey) {
       return null;
@@ -459,8 +493,17 @@ export default function SqlStudio() {
     if (unsubscribe) {
       void unsubscribe();
       delete liveUnsubscribeRef.current[tabId];
+      delete liveRequestNextBatchRef.current[tabId];
       delete liveSubscriptionIdRef.current[tabId];
     }
+    setLiveBatchByTab((previous) => {
+      if (!(tabId in previous)) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[tabId];
+      return next;
+    });
   }, []);
 
   const clearWsListeners = useCallback(() => {
@@ -576,8 +619,31 @@ export default function SqlStudio() {
     updateTab(tabId, { liveStatus: "idle" });
   }, [cleanupLiveSubscription, clearWsListeners, dispatch, updateTab]);
 
+  const fetchNextLiveBatch = useCallback(async (tabId: string) => {
+    const requestNextBatch = liveRequestNextBatchRef.current[tabId];
+    if (!requestNextBatch) {
+      return;
+    }
+
+    try {
+      await requestNextBatch();
+    } catch (error) {
+      dispatch(appendWorkspaceResultLog({
+        tabId,
+        entry: createLogEntry(
+          error instanceof Error ? error.message : "Failed to fetch next live batch",
+          "error",
+          user?.username,
+          error,
+        ),
+        statusOverride: "error",
+      }));
+    }
+  }, [dispatch, user?.username]);
+
   const startLiveQuery = useCallback(async (tab: QueryTab, sqlOverride?: string) => {
     const sqlToRun = stripAutoSelectLimitForLiveSql(sqlOverride ?? tab.sql);
+    const tracedSubscribeSql = stripTrailingOptionsClause(sqlToRun);
 
     if (!sqlToRun.trim()) {
       return;
@@ -607,6 +673,15 @@ export default function SqlStudio() {
     setClientSendListener((message: string) => {
       if (liveGenRef.current[tab.id] !== gen) return;
       const messageType = extractWsMessageType(message);
+      const messageSql = extractWsSubscriptionSql(message);
+      if (
+        messageType === "subscribe"
+        && messageSql
+        && stripTrailingOptionsClause(messageSql) !== tracedSubscribeSql
+      ) return;
+      const msgSubId = extractWsSubscriptionId(message);
+      const tabSubId = liveSubscriptionIdRef.current[tab.id];
+      if (msgSubId !== null && tabSubId !== undefined && msgSubId !== tabSubId) return;
       dispatch(appendWorkspaceResultLog({
         tabId: tab.id,
         entry: createLogEntry(
@@ -674,7 +749,7 @@ export default function SqlStudio() {
     let hasConnected = false;
 
     try {
-      const unsubscribe = await subscribe(sqlToRun, (msg: ServerMessage) => {
+      const handle = await subscribeWithHandle(sqlToRun, (msg: ServerMessage) => {
         if (liveGenRef.current[tab.id] !== gen) return;
 
         switch (msg.type) {
@@ -699,6 +774,15 @@ export default function SqlStudio() {
             // Record this tab's subscription ID so the receive listener can
             // filter out frames from other concurrent subscriptions.
             liveSubscriptionIdRef.current[tab.id] = msg.subscription_id;
+            setLiveBatchByTab((previous) => ({
+              ...previous,
+              [tab.id]: {
+                hasMore: msg.batch_control.has_more,
+                batchNum: displayBatchNum(msg.batch_control.batch_num),
+                status: msg.batch_control.status,
+                subscriptionId: msg.subscription_id,
+              },
+            }));
             if (msg.schema.length > 0) {
               dispatch(setWorkspaceLiveSchema({
                 tabId: tab.id,
@@ -714,12 +798,22 @@ export default function SqlStudio() {
             if (!hasConnected) {
               hasConnected = true;
             }
+            setLiveBatchByTab((previous) => ({
+              ...previous,
+              [tab.id]: {
+                hasMore: msg.batch_control.has_more,
+                batchNum: displayBatchNum(msg.batch_control.batch_num),
+                status: msg.batch_control.status,
+                subscriptionId: msg.subscription_id,
+              },
+            }));
             const rows = normalizeLiveRows(msg.rows);
             dispatch(appendWorkspaceLiveRows({
               tabId: tab.id,
               rows,
               changeType: "initial",
               schema: undefined,
+              batchNum: displayBatchNum(msg.batch_control.batch_num),
             }));
             updateTab(tab.id, { liveStatus: "connected", resultView: "results" });
             dispatch(setWorkspaceRunning(false));
@@ -772,11 +866,13 @@ export default function SqlStudio() {
 
       // If cancelled while awaiting subscribe, unsubscribe immediately
       if (liveGenRef.current[tab.id] !== gen) {
-        void unsubscribe();
+        void handle.unsubscribe();
         return;
       }
 
-      liveUnsubscribeRef.current[tab.id] = unsubscribe;
+      liveUnsubscribeRef.current[tab.id] = handle.unsubscribe;
+      liveRequestNextBatchRef.current[tab.id] = handle.requestNextBatch;
+      liveSubscriptionIdRef.current[tab.id] = handle.id;
     } catch (error) {
       if (liveGenRef.current[tab.id] !== gen) return;
 
@@ -1203,11 +1299,14 @@ export default function SqlStudio() {
                     result={activeResult}
                     isRunning={isRunning}
                     isLiveMode={activeTab.isLive}
+                    liveBatch={activeLiveBatch}
+                    liveAutoFetchBatches={activeTab.subscriptionOptions?.auto_fetch_batches ?? false}
                     activeSql={activeTab.sql}
                     selectedTable={selectedTable}
                     currentUsername={user?.username ?? "admin"}
                     resultView={activeTab.resultView}
                     onResultViewChange={(view) => updateActiveTab({ resultView: view })}
+                    onFetchNextBatch={() => fetchNextLiveBatch(activeTab.id)}
                     onRefreshAfterCommit={() => executeQueryForTab(activeTab.id, activeTab.sql, activeTab.title)}
                   />
                 </ResizablePanel>

--- a/ui/src/services/sqlStudioWorkspaceSyncService.test.ts
+++ b/ui/src/services/sqlStudioWorkspaceSyncService.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecuteSql = vi.fn();
-const mockSubscribeTable = vi.fn();
+const mockSubscribe = vi.fn();
 const mockDb = {
   select: vi.fn(),
   insert: vi.fn(),
@@ -10,7 +10,7 @@ const mockDb = {
 
 vi.mock("@/lib/kalam-client", () => ({
   executeSql: (...args: unknown[]) => mockExecuteSql(...args),
-  getClient: vi.fn(() => ({ id: "client" })),
+  subscribe: (...args: unknown[]) => mockSubscribe(...args),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -21,7 +21,6 @@ vi.mock("@kalamdb/orm", async () => {
   const { pgTable } = await import("drizzle-orm/pg-core");
   return {
     kTable: pgTable,
-    subscribeTable: (...args: unknown[]) => mockSubscribeTable(...args),
   };
 });
 
@@ -29,7 +28,7 @@ describe("sqlStudioWorkspaceSyncService", () => {
   beforeEach(() => {
     vi.resetModules();
     mockExecuteSql.mockReset();
-    mockSubscribeTable.mockReset();
+    mockSubscribe.mockReset();
     mockDb.select.mockReset();
     mockDb.insert.mockReset();
     mockDb.update.mockReset();
@@ -82,7 +81,7 @@ describe("sqlStudioWorkspaceSyncService", () => {
     mockSelectOnce([{ id: "sql-studio-workspace", payload: workspace }]);
     mockSelectOnce([]);
     mockDb.insert.mockReturnValue({ values: insertValues });
-    mockSubscribeTable.mockResolvedValue(async () => {});
+    mockSubscribe.mockResolvedValue(async () => {});
 
     const { subscribeToSyncedSqlStudioWorkspaceState } = await import("@/services/sqlStudioWorkspaceSyncService");
     const onChange = vi.fn();
@@ -90,11 +89,10 @@ describe("sqlStudioWorkspaceSyncService", () => {
     await subscribeToSyncedSqlStudioWorkspaceState("admin", onChange);
 
     expect(onChange).toHaveBeenCalledWith(workspace);
-    expect(mockSubscribeTable).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "client" }),
-      expect.any(Object),
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      "SELECT * FROM dba.favorites WHERE id = 'sql-studio-state:admin:workspace'",
       expect.any(Function),
-      expect.objectContaining({ where: expect.any(Object) }),
+      { last_rows: 0, batch_size: 1, auto_fetch_batches: false },
     );
     expect(mockExecuteSql).toHaveBeenCalledWith(
       "CREATE TABLE IF NOT EXISTS dba.favorites (id TEXT PRIMARY KEY, payload JSON) WITH (TYPE='USER')",

--- a/ui/src/services/sqlStudioWorkspaceSyncService.ts
+++ b/ui/src/services/sqlStudioWorkspaceSyncService.ts
@@ -3,8 +3,7 @@ import type {
   SqlStudioPersistedQueryTab,
   SqlStudioPersistedSavedQuery,
 } from "@/components/sql-studio-v2/shared/workspaceState";
-import { subscribeTable, type TableSubscriptionEvent } from "@kalamdb/orm";
-import { executeSql, getClient, type Unsubscribe } from "@/lib/kalam-client";
+import { executeSql, subscribe, type Unsubscribe } from "@/lib/kalam-client";
 import { getDb } from "@/lib/db";
 import type { DbaFavoriteRow } from "@/lib/models";
 import { dba_favorites } from "@/lib/schema";
@@ -35,7 +34,7 @@ function normalizeSubscriptionOptions(value: unknown) {
   }
 
   const record = value as Record<string, unknown>;
-  const result: Record<string, string | number> = {};
+  const result: Record<string, string | number | boolean> = {};
 
   if (typeof record.batch_size === "number" && Number.isFinite(record.batch_size)) {
     result.batch_size = record.batch_size;
@@ -45,6 +44,9 @@ function normalizeSubscriptionOptions(value: unknown) {
   }
   if (typeof record.from === "string" || typeof record.from === "number") {
     result.from = String(record.from);
+  }
+  if (typeof record.auto_fetch_batches === "boolean") {
+    result.auto_fetch_batches = record.auto_fetch_batches;
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
@@ -163,6 +165,10 @@ function buildWorkspaceRowId(username?: string | null): string {
   }
 
   return `sql-studio-state:${normalizedUsername}:${SQL_STUDIO_WORKSPACE_STATE_KEY}`;
+}
+
+function escapeSqlString(value: string): string {
+  return value.replace(/'/g, "''");
 }
 
 async function ensureWorkspaceTable(): Promise<void> {
@@ -315,18 +321,27 @@ export async function subscribeToSyncedSqlStudioWorkspaceState(
   onChange(initialWorkspace);
 
   const rowId = buildWorkspaceRowId(username);
-  const client = getClient();
-  if (!client) {
-    throw new Error("KalamDB client not initialized");
-  }
+  const sql = `SELECT * FROM ${SQL_STUDIO_WORKSPACE_TABLE} WHERE id = '${escapeSqlString(rowId)}'`;
 
-  return subscribeTable(
-    client,
-    dba_favorites,
-    (event: TableSubscriptionEvent<typeof dba_favorites>) => {
-      onChange(parseWorkspaceRow(event.rows?.[0] ?? null));
+  return subscribe(
+    sql,
+    (event) => {
+      if (event.type === "initial_data_batch") {
+        if (event.rows.length > 0) {
+          onChange(parseWorkspaceRow(event.rows[0]));
+        }
+        return;
+      }
+
+      if (event.type === "change") {
+        if (event.change_type === "delete") {
+          onChange(null);
+          return;
+        }
+        onChange(parseWorkspaceRow(event.rows?.[0] ?? null));
+      }
     },
-    { where: eq(dba_favorites.id, rowId) },
+    { last_rows: 0, batch_size: 1, auto_fetch_batches: false },
   );
 }
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import fs from "fs";
-import type { PluginOption } from "vite";
 
 function normalizeOrigin(url: string): string {
   return url.replace(/\/+$/, "");
@@ -37,21 +36,6 @@ const cleanupPlugin = () => ({
   }
 });
 
-const runtimeConfigScriptPlugin = (): PluginOption => ({
-  name: "runtime-config-script",
-  transformIndexHtml() {
-    return [
-      {
-        tag: "script",
-        attrs: {
-          src: "%BASE_URL%runtime-config.js",
-        },
-        injectTo: "body",
-      },
-    ];
-  },
-});
-
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, "");
@@ -59,7 +43,7 @@ export default defineConfig(({ mode }) => {
   const backendWebSocketOrigin = toWebSocketOrigin(backendOrigin);
 
   return {
-    plugins: [react(), cleanupPlugin(), runtimeConfigScriptPlugin()],
+    plugins: [react(), cleanupPlugin()],
     // Base path for production build (embedded in server at /ui/)
     base: "/ui/",
     resolve: {


### PR DESCRIPTION
Introduce client-side control for auto-fetching initial-data batches across the stack. Adds an auto_fetch_batches option to subscription types (Rust, TS, Dart), parses it in the CLI, and wires it through the WASM client so the client can automatically request subsequent batches or let the UI/SDK request them manually. Exposes requestNextBatch on the WASM & TypeScript clients and a SubscriptionHandle with requestNextBatch/unsubscribe, plus tracing hooks to emit outbound WS messages for debugging. UI changes add live query indicators, a toggle for auto fetch, a "Fetch next batch" button, and live batch metadata handling. Also includes related tests, a small backend test about auditing for delegated DML, and minor example/index updates.
